### PR TITLE
feat: 이메일 등록 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/dnd/modutime/advice/response/ExceptionResponse.java
+++ b/src/main/java/com/dnd/modutime/advice/response/ExceptionResponse.java
@@ -1,12 +1,13 @@
 package com.dnd.modutime.advice.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExceptionResponse {
     private String message;
 }

--- a/src/main/java/com/dnd/modutime/dto/request/AvailableDateTimeRequest.java
+++ b/src/main/java/com/dnd/modutime/dto/request/AvailableDateTimeRequest.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class AvailableDateTimeRequest {
 

--- a/src/main/java/com/dnd/modutime/dto/request/EmailCreationRequest.java
+++ b/src/main/java/com/dnd/modutime/dto/request/EmailCreationRequest.java
@@ -1,0 +1,14 @@
+package com.dnd.modutime.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailCreationRequest {
+
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/dnd/modutime/dto/request/EmailCreationRequest.java
+++ b/src/main/java/com/dnd/modutime/dto/request/EmailCreationRequest.java
@@ -1,11 +1,12 @@
 package com.dnd.modutime.dto.request;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class EmailCreationRequest {
 

--- a/src/main/java/com/dnd/modutime/dto/request/LoginRequest.java
+++ b/src/main/java/com/dnd/modutime/dto/request/LoginRequest.java
@@ -1,11 +1,12 @@
 package com.dnd.modutime.dto.request;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class LoginRequest {
 

--- a/src/main/java/com/dnd/modutime/dto/request/RoomRequest.java
+++ b/src/main/java/com/dnd/modutime/dto/request/RoomRequest.java
@@ -2,16 +2,16 @@ package com.dnd.modutime.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
-
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class RoomRequest {
 

--- a/src/main/java/com/dnd/modutime/dto/request/TimeReplaceRequest.java
+++ b/src/main/java/com/dnd/modutime/dto/request/TimeReplaceRequest.java
@@ -1,13 +1,14 @@
 package com.dnd.modutime.dto.request;
 
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class TimeReplaceRequest {
 

--- a/src/main/java/com/dnd/modutime/dto/request/TimerRequest.java
+++ b/src/main/java/com/dnd/modutime/dto/request/TimerRequest.java
@@ -1,11 +1,12 @@
 package com.dnd.modutime.dto.request;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class TimerRequest {
     private int day;

--- a/src/main/java/com/dnd/modutime/dto/response/AvailableDateTimeResponse.java
+++ b/src/main/java/com/dnd/modutime/dto/response/AvailableDateTimeResponse.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class AvailableDateTimeResponse {
 

--- a/src/main/java/com/dnd/modutime/dto/response/AvailableTimeInfo.java
+++ b/src/main/java/com/dnd/modutime/dto/response/AvailableTimeInfo.java
@@ -2,12 +2,13 @@ package com.dnd.modutime.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalTime;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class AvailableTimeInfo {
 

--- a/src/main/java/com/dnd/modutime/dto/response/EmailResponse.java
+++ b/src/main/java/com/dnd/modutime/dto/response/EmailResponse.java
@@ -1,0 +1,13 @@
+package com.dnd.modutime.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailResponse {
+
+    private String email;
+}

--- a/src/main/java/com/dnd/modutime/dto/response/EmailResponse.java
+++ b/src/main/java/com/dnd/modutime/dto/response/EmailResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class EmailResponse {
 

--- a/src/main/java/com/dnd/modutime/dto/response/EmailResponse.java
+++ b/src/main/java/com/dnd/modutime/dto/response/EmailResponse.java
@@ -1,13 +1,22 @@
 package com.dnd.modutime.dto.response;
 
+import com.dnd.modutime.participant.domain.Email;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class EmailResponse {
 
     private String email;
+
+    public static EmailResponse from(Email email) {
+        if (email == null) {
+            return new EmailResponse(null);
+        }
+        return new EmailResponse(email.getValue());
+    }
 }

--- a/src/main/java/com/dnd/modutime/dto/response/LoginPageResponse.java
+++ b/src/main/java/com/dnd/modutime/dto/response/LoginPageResponse.java
@@ -1,11 +1,12 @@
 package com.dnd.modutime.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class LoginPageResponse {
 

--- a/src/main/java/com/dnd/modutime/dto/response/RoomCreationResponse.java
+++ b/src/main/java/com/dnd/modutime/dto/response/RoomCreationResponse.java
@@ -1,12 +1,13 @@
 package com.dnd.modutime.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class RoomCreationResponse {
 

--- a/src/main/java/com/dnd/modutime/dto/response/RoomInfoResponse.java
+++ b/src/main/java/com/dnd/modutime/dto/response/RoomInfoResponse.java
@@ -6,12 +6,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class RoomInfoResponse {
 

--- a/src/main/java/com/dnd/modutime/dto/response/TimeAndCountPerDate.java
+++ b/src/main/java/com/dnd/modutime/dto/response/TimeAndCountPerDate.java
@@ -3,12 +3,13 @@ package com.dnd.modutime.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class TimeAndCountPerDate {
 

--- a/src/main/java/com/dnd/modutime/dto/response/TimeBlockResponse.java
+++ b/src/main/java/com/dnd/modutime/dto/response/TimeBlockResponse.java
@@ -1,12 +1,13 @@
 package com.dnd.modutime.dto.response;
 
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class TimeBlockResponse {
 

--- a/src/main/java/com/dnd/modutime/dto/response/TimeTableResponse.java
+++ b/src/main/java/com/dnd/modutime/dto/response/TimeTableResponse.java
@@ -6,12 +6,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class TimeTableResponse {
 

--- a/src/main/java/com/dnd/modutime/participant/application/ParticipantService.java
+++ b/src/main/java/com/dnd/modutime/participant/application/ParticipantService.java
@@ -1,6 +1,7 @@
 package com.dnd.modutime.participant.application;
 
 import com.dnd.modutime.dto.request.EmailCreationRequest;
+import com.dnd.modutime.dto.response.EmailResponse;
 import com.dnd.modutime.participant.domain.Participant;
 import com.dnd.modutime.exception.NotFoundException;
 import com.dnd.modutime.participant.repository.ParticipantRepository;
@@ -29,6 +30,11 @@ public class ParticipantService {
                               EmailCreationRequest emailCreationRequest) {
         Participant participant = getByRoomUuidAndName(roomUuid, emailCreationRequest.getName());
         participant.registerEmail(emailCreationRequest.getEmail());
+    }
+
+    public EmailResponse getEmail(String roomUuid, String name) {
+        Participant participant = getByRoomUuidAndName(roomUuid, name);
+        return new EmailResponse(participant.getEmail());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dnd/modutime/participant/application/ParticipantService.java
+++ b/src/main/java/com/dnd/modutime/participant/application/ParticipantService.java
@@ -2,6 +2,7 @@ package com.dnd.modutime.participant.application;
 
 import com.dnd.modutime.dto.request.EmailCreationRequest;
 import com.dnd.modutime.dto.response.EmailResponse;
+import com.dnd.modutime.participant.domain.Email;
 import com.dnd.modutime.participant.domain.Participant;
 import com.dnd.modutime.exception.NotFoundException;
 import com.dnd.modutime.participant.repository.ParticipantRepository;
@@ -29,12 +30,12 @@ public class ParticipantService {
     public void registerEmail(String roomUuid,
                               EmailCreationRequest emailCreationRequest) {
         Participant participant = getByRoomUuidAndName(roomUuid, emailCreationRequest.getName());
-        participant.registerEmail(emailCreationRequest.getEmail());
+        participant.registerEmail(new Email(emailCreationRequest.getEmail()));
     }
 
     public EmailResponse getEmail(String roomUuid, String name) {
         Participant participant = getByRoomUuidAndName(roomUuid, name);
-        return new EmailResponse(participant.getEmail());
+        return EmailResponse.from(participant.getEmailOrNull());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dnd/modutime/participant/application/ParticipantService.java
+++ b/src/main/java/com/dnd/modutime/participant/application/ParticipantService.java
@@ -1,12 +1,15 @@
 package com.dnd.modutime.participant.application;
 
+import com.dnd.modutime.dto.request.EmailCreationRequest;
 import com.dnd.modutime.participant.domain.Participant;
 import com.dnd.modutime.exception.NotFoundException;
 import com.dnd.modutime.participant.repository.ParticipantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ParticipantService {
 
@@ -17,10 +20,18 @@ public class ParticipantService {
         participantRepository.save(participant);
     }
 
+    @Transactional(readOnly = true)
     public boolean existsByName(String roomUuid, String name) {
         return participantRepository.existsByRoomUuidAndName(roomUuid, name);
     }
 
+    public void registerEmail(String roomUuid,
+                              EmailCreationRequest emailCreationRequest) {
+        Participant participant = getByRoomUuidAndName(roomUuid, emailCreationRequest.getName());
+        participant.registerEmail(emailCreationRequest.getEmail());
+    }
+
+    @Transactional(readOnly = true)
     public Participant getByRoomUuidAndName(String roomUuid, String name) {
         return participantRepository.findByRoomUuidAndName(roomUuid, name)
                 .orElseThrow(() -> new NotFoundException("해당하는 참여자를 찾을 수 없습니다."));

--- a/src/main/java/com/dnd/modutime/participant/controller/ParticipantController.java
+++ b/src/main/java/com/dnd/modutime/participant/controller/ParticipantController.java
@@ -1,0 +1,26 @@
+package com.dnd.modutime.participant.controller;
+
+import com.dnd.modutime.dto.request.EmailCreationRequest;
+import com.dnd.modutime.participant.application.ParticipantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/room/{roomUuid}")
+@RequiredArgsConstructor
+public class ParticipantController {
+
+    private final ParticipantService participantService;
+
+    @PostMapping("/email")
+    public ResponseEntity<Void> registerEmail(@PathVariable String roomUuid,
+                                              @RequestBody EmailCreationRequest emailCreationRequest) {
+        participantService.registerEmail(roomUuid, emailCreationRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/dnd/modutime/participant/controller/ParticipantController.java
+++ b/src/main/java/com/dnd/modutime/participant/controller/ParticipantController.java
@@ -1,13 +1,16 @@
 package com.dnd.modutime.participant.controller;
 
 import com.dnd.modutime.dto.request.EmailCreationRequest;
+import com.dnd.modutime.dto.response.EmailResponse;
 import com.dnd.modutime.participant.application.ParticipantService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,5 +25,12 @@ public class ParticipantController {
                                               @RequestBody EmailCreationRequest emailCreationRequest) {
         participantService.registerEmail(roomUuid, emailCreationRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/email")
+    public ResponseEntity<EmailResponse> getEmail(@PathVariable String roomUuid,
+                                                  @RequestParam String name) {
+        EmailResponse emailResponse = participantService.getEmail(roomUuid, name);
+        return ResponseEntity.ok(emailResponse);
     }
 }

--- a/src/main/java/com/dnd/modutime/participant/domain/Email.java
+++ b/src/main/java/com/dnd/modutime/participant/domain/Email.java
@@ -3,10 +3,11 @@ package com.dnd.modutime.participant.domain;
 import java.util.regex.Pattern;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @Embeddable
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Email {
 
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");

--- a/src/main/java/com/dnd/modutime/participant/domain/Email.java
+++ b/src/main/java/com/dnd/modutime/participant/domain/Email.java
@@ -1,0 +1,31 @@
+package com.dnd.modutime.participant.domain;
+
+import java.util.regex.Pattern;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+public class Email {
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");
+
+    @Column(name = "email")
+    private String value;
+
+    public Email(String value) {
+        validateRightEmailPattern(value);
+        this.value = value;
+    }
+
+    private void validateRightEmailPattern(String email) {
+        if (!EMAIL_PATTERN.matcher(email).find()) {
+            throw new IllegalArgumentException("email 형식에 맞지 않습니다.");
+        }
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/dnd/modutime/participant/domain/Participant.java
+++ b/src/main/java/com/dnd/modutime/participant/domain/Participant.java
@@ -12,11 +12,12 @@ import javax.persistence.Id;
 import javax.persistence.PostPersist;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"room_uuid", "name"})})
 public class Participant extends AbstractAggregateRoot<Participant> {
 

--- a/src/main/java/com/dnd/modutime/participant/domain/Participant.java
+++ b/src/main/java/com/dnd/modutime/participant/domain/Participant.java
@@ -102,4 +102,8 @@ public class Participant extends AbstractAggregateRoot<Participant> {
     public String getName() {
         return name;
     }
+
+    public String getEmail() {
+        return email;
+    }
 }

--- a/src/main/java/com/dnd/modutime/participant/domain/Participant.java
+++ b/src/main/java/com/dnd/modutime/participant/domain/Participant.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.AbstractAggregateRoot;
 public class Participant extends AbstractAggregateRoot<Participant> {
 
     private static final Pattern PASSWORD_PATTERN = Pattern.compile("^[0-9]{4}$");
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -76,7 +77,14 @@ public class Participant extends AbstractAggregateRoot<Participant> {
     }
 
     public void registerEmail(String email) {
+        validateRightEmailPattern(email);
         this.email = email;
+    }
+
+    private void validateRightEmailPattern(String email) {
+        if (!EMAIL_PATTERN.matcher(email).find()) {
+            throw new IllegalArgumentException("email 형식에 맞지 않습니다.");
+        }
     }
 
     public boolean hasEmail() {

--- a/src/main/java/com/dnd/modutime/participant/domain/Participant.java
+++ b/src/main/java/com/dnd/modutime/participant/domain/Participant.java
@@ -5,6 +5,7 @@ import static javax.persistence.GenerationType.IDENTITY;
 import com.dnd.modutime.timeblock.application.ParticipantCreationEvent;
 import java.util.regex.Pattern;
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -20,7 +21,6 @@ import org.springframework.data.domain.AbstractAggregateRoot;
 public class Participant extends AbstractAggregateRoot<Participant> {
 
     private static final Pattern PASSWORD_PATTERN = Pattern.compile("^[0-9]{4}$");
-    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -35,8 +35,8 @@ public class Participant extends AbstractAggregateRoot<Participant> {
     @Column(nullable = false)
     private String password;
 
-    @Column
-    private String email;
+    @Embedded
+    private Email email;
 
     public Participant(String roomUuid, String name, String password) {
         validateRoomUuid(roomUuid);
@@ -76,16 +76,15 @@ public class Participant extends AbstractAggregateRoot<Participant> {
         return !PASSWORD_PATTERN.matcher(password).find();
     }
 
-    public void registerEmail(String email) {
-        validateRightEmailPattern(email);
+    public void registerEmail(Email email) {
         this.email = email;
     }
 
-    private void validateRightEmailPattern(String email) {
-        if (!EMAIL_PATTERN.matcher(email).find()) {
-            throw new IllegalArgumentException("email 형식에 맞지 않습니다.");
-        }
-    }
+//    private void validateRightEmailPattern(String email) {
+//        if (!EMAIL_PATTERN.matcher(email).find()) {
+//            throw new IllegalArgumentException("email 형식에 맞지 않습니다.");
+//        }
+//    }
 
     public boolean hasEmail() {
         return email != null;
@@ -103,7 +102,7 @@ public class Participant extends AbstractAggregateRoot<Participant> {
         return name;
     }
 
-    public String getEmail() {
+    public Email getEmailOrNull() {
         return email;
     }
 }

--- a/src/main/java/com/dnd/modutime/room/domain/Room.java
+++ b/src/main/java/com/dnd/modutime/room/domain/Room.java
@@ -18,11 +18,12 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.PostPersist;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.AbstractAggregateRoot;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Room extends AbstractAggregateRoot<Room> {
 
     @Id

--- a/src/main/java/com/dnd/modutime/room/domain/RoomDate.java
+++ b/src/main/java/com/dnd/modutime/room/domain/RoomDate.java
@@ -7,10 +7,11 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RoomDate {
 
     @Id

--- a/src/main/java/com/dnd/modutime/timeblock/domain/AvailableDateTime.java
+++ b/src/main/java/com/dnd/modutime/timeblock/domain/AvailableDateTime.java
@@ -12,10 +12,11 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AvailableDateTime {
 
     @Id

--- a/src/main/java/com/dnd/modutime/timeblock/domain/AvailableTime.java
+++ b/src/main/java/com/dnd/modutime/timeblock/domain/AvailableTime.java
@@ -6,10 +6,11 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AvailableTime {
 
     @Id

--- a/src/main/java/com/dnd/modutime/timetable/domain/DateInfo.java
+++ b/src/main/java/com/dnd/modutime/timetable/domain/DateInfo.java
@@ -15,10 +15,11 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DateInfo {
 
     @Id

--- a/src/main/java/com/dnd/modutime/timetable/domain/TimeInfo.java
+++ b/src/main/java/com/dnd/modutime/timetable/domain/TimeInfo.java
@@ -6,10 +6,11 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TimeInfo {
 
     @Id

--- a/src/main/java/com/dnd/modutime/timetable/domain/TimeTable.java
+++ b/src/main/java/com/dnd/modutime/timetable/domain/TimeTable.java
@@ -9,10 +9,11 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TimeTable {
 
     @Id

--- a/src/test/java/com/dnd/modutime/acceptance/AcceptanceSupporter.java
+++ b/src/test/java/com/dnd/modutime/acceptance/AcceptanceSupporter.java
@@ -7,6 +7,7 @@ import com.dnd.modutime.dto.request.AvailableDateTimeRequest;
 import com.dnd.modutime.dto.request.LoginRequest;
 import com.dnd.modutime.dto.request.RoomRequest;
 import com.dnd.modutime.dto.request.TimeReplaceRequest;
+import com.dnd.modutime.dto.response.EmailResponse;
 import com.dnd.modutime.dto.response.RoomCreationResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -86,5 +87,10 @@ public class AcceptanceSupporter {
     protected void 로그인후_시간을_등록한다(String roomUuid, String participantName, List<AvailableDateTimeRequest> requests) {
         로그인_참여자_1234(roomUuid, participantName);
         시간을_등록한다(roomUuid, participantName, requests);
+    }
+
+    protected EmailResponse 이메일을_조회한다(String roomUuid, String participantName) {
+        ExtractableResponse<Response> response = get("/api/room/" + roomUuid + "/email?name=" + participantName);
+        return response.body().as(EmailResponse.class);
     }
 }

--- a/src/test/java/com/dnd/modutime/acceptance/ParticipantAcceptanceTest.java
+++ b/src/test/java/com/dnd/modutime/acceptance/ParticipantAcceptanceTest.java
@@ -1,0 +1,33 @@
+package com.dnd.modutime.acceptance;
+
+import static com.dnd.modutime.fixture.TimeFixture._11_00;
+import static com.dnd.modutime.fixture.TimeFixture._12_00;
+import static com.dnd.modutime.fixture.TimeFixture._2023_02_09;
+import static com.dnd.modutime.fixture.TimeFixture.getAvailableDateTimeRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dnd.modutime.dto.request.EmailCreationRequest;
+import com.dnd.modutime.dto.response.RoomCreationResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+public class ParticipantAcceptanceTest extends AcceptanceSupporter {
+
+    @Test
+    void 이메일을_등록한다() {
+        RoomCreationResponse roomCreationResponse = 방_생성();
+        String roomUuid = roomCreationResponse.getUuid();
+        로그인_참여자_1234(roomUuid, "참여자1");
+        시간을_등록한다(roomUuid, "참여자1", getAvailableDateTimeRequest(
+                _2023_02_09, List.of(_11_00, _12_00)
+        ));
+
+        ExtractableResponse<Response> response = post("/api/room/" + roomUuid + "/email", new EmailCreationRequest(
+                "참여자1", "dongho1088@gmail.com"
+        ));
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/com/dnd/modutime/acceptance/ParticipantAcceptanceTest.java
+++ b/src/test/java/com/dnd/modutime/acceptance/ParticipantAcceptanceTest.java
@@ -7,6 +7,7 @@ import static com.dnd.modutime.fixture.TimeFixture.getAvailableDateTimeRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.dnd.modutime.dto.request.EmailCreationRequest;
+import com.dnd.modutime.dto.response.EmailResponse;
 import com.dnd.modutime.dto.response.RoomCreationResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -16,18 +17,47 @@ import org.springframework.http.HttpStatus;
 
 public class ParticipantAcceptanceTest extends AcceptanceSupporter {
 
+    private static final String PARTICIPANT_NAME = "참여자1";
+    private static final String EMAIL = "dongho1088@gmail.com";
+
     @Test
     void 이메일을_등록한다() {
         RoomCreationResponse roomCreationResponse = 방_생성();
         String roomUuid = roomCreationResponse.getUuid();
-        로그인_참여자_1234(roomUuid, "참여자1");
-        시간을_등록한다(roomUuid, "참여자1", getAvailableDateTimeRequest(
+        로그인_참여자_1234(roomUuid, PARTICIPANT_NAME);
+        시간을_등록한다(roomUuid, PARTICIPANT_NAME, getAvailableDateTimeRequest(
+                _2023_02_09, List.of(_11_00, _12_00)
+        ));
+        ExtractableResponse<Response> response = post("/api/room/" + roomUuid + "/email", new EmailCreationRequest(
+                PARTICIPANT_NAME, EMAIL
+        ));
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 이메일을_조회한다() {
+        RoomCreationResponse roomCreationResponse = 방_생성();
+        String roomUuid = roomCreationResponse.getUuid();
+        로그인_참여자_1234(roomUuid, PARTICIPANT_NAME);
+        시간을_등록한다(roomUuid, PARTICIPANT_NAME, getAvailableDateTimeRequest(
+                _2023_02_09, List.of(_11_00, _12_00)
+        ));
+        post("/api/room/" + roomUuid + "/email", new EmailCreationRequest(PARTICIPANT_NAME, EMAIL));
+
+        EmailResponse emailResponse = 이메일을_조회한다(roomUuid, PARTICIPANT_NAME);
+        assertThat(emailResponse.getEmail()).isEqualTo(EMAIL);
+    }
+
+    @Test
+    void 이메일을_조회한다_없으면_null을_반환한다() {
+        RoomCreationResponse roomCreationResponse = 방_생성();
+        String roomUuid = roomCreationResponse.getUuid();
+        로그인_참여자_1234(roomUuid, PARTICIPANT_NAME);
+        시간을_등록한다(roomUuid, PARTICIPANT_NAME, getAvailableDateTimeRequest(
                 _2023_02_09, List.of(_11_00, _12_00)
         ));
 
-        ExtractableResponse<Response> response = post("/api/room/" + roomUuid + "/email", new EmailCreationRequest(
-                "참여자1", "dongho1088@gmail.com"
-        ));
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        EmailResponse emailResponse = 이메일을_조회한다(roomUuid, PARTICIPANT_NAME);
+        assertThat(emailResponse.getEmail()).isNull();
     }
 }

--- a/src/test/java/com/dnd/modutime/acceptance/TimeTableAcceptanceTest.java
+++ b/src/test/java/com/dnd/modutime/acceptance/TimeTableAcceptanceTest.java
@@ -97,7 +97,7 @@ public class TimeTableAcceptanceTest extends AcceptanceSupporter {
         );
     }
 
-    private void 두명의_날짜를_등록한다(final String roomUuid) {
+    private void 두명의_날짜를_등록한다(String roomUuid) {
         로그인후_시간을_등록한다(roomUuid,
                 "김동호",
                 List.of(getAvailableDateTimeRequest(_2023_02_08, null),

--- a/src/test/java/com/dnd/modutime/participant/domain/EmailTest.java
+++ b/src/test/java/com/dnd/modutime/participant/domain/EmailTest.java
@@ -1,0 +1,16 @@
+package com.dnd.modutime.participant.domain;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EmailTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "aa", "asd.com", "asd@", "asd@@email.com"})
+    void 이메일형식이_맞지않으면_예외를_발생한다(String email) {
+        assertThatThrownBy(() -> new Email(email))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/dnd/modutime/participant/domain/ParticipantTest.java
+++ b/src/test/java/com/dnd/modutime/participant/domain/ParticipantTest.java
@@ -29,6 +29,14 @@ public class ParticipantTest {
         assertThat(participant.hasEmail()).isTrue();
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"", "aa", "asd.com", "asd@", "asd@@email.com"})
+    void 이메일형식이_맞지않으면_예외를_발생한다(String email) {
+        Participant participant = getParticipant("김동호", "1234");
+        assertThatThrownBy(() -> participant.registerEmail(email))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
     @Test
     void 이메일은_null이면_이메일을_가지고_있지_않다고_판단한다() {
         Participant participant = getParticipant("김동호", "1234");

--- a/src/test/java/com/dnd/modutime/participant/domain/ParticipantTest.java
+++ b/src/test/java/com/dnd/modutime/participant/domain/ParticipantTest.java
@@ -25,16 +25,8 @@ public class ParticipantTest {
     @Test
     void 이메일을_추가한다() {
         Participant participant = getParticipant("김동호", "1234");
-        participant.registerEmail("participant@email.com");
+        participant.registerEmail(new Email("participant@email.com"));
         assertThat(participant.hasEmail()).isTrue();
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"", "aa", "asd.com", "asd@", "asd@@email.com"})
-    void 이메일형식이_맞지않으면_예외를_발생한다(String email) {
-        Participant participant = getParticipant("김동호", "1234");
-        assertThatThrownBy(() -> participant.registerEmail(email))
-                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
closed #22 


## 어떤 기능을 개발했나요?

- 이메일 조회
- 이메일 등록



## 어떻게 해결했나요?



## 어떤 부분에 집중하여 리뷰해야 할까요?

- email을 원시값 포장했습니다.
- 기본 생성자를 사용하는 롬복의 제어자를 PROTECTED로 설정했습니다.
    - 외부에서 기본생성자로 생성하는 것 방지
    - JPA에서는 protected 만으로도 생성가능

## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.