### PR TITLE
refactor: 참여자 이름 글자수 4글자 이내로 제한

### DIFF
--- a/src/main/java/com/dnd/modutime/participant/domain/Participant.java
+++ b/src/main/java/com/dnd/modutime/participant/domain/Participant.java
@@ -1,18 +1,13 @@
 package com.dnd.modutime.participant.domain;
 
-import static javax.persistence.GenerationType.IDENTITY;
-
 import com.dnd.modutime.timeblock.application.ParticipantCreationEvent;
-import java.util.regex.Pattern;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.PostPersist;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.AbstractAggregateRoot;
+
+import javax.persistence.*;
+import java.util.regex.Pattern;
+
+import static javax.persistence.GenerationType.IDENTITY;
 
 @Entity
 @NoArgsConstructor
@@ -28,7 +23,7 @@ public class Participant extends AbstractAggregateRoot<Participant> {
     @Column(name = "room_uuid", nullable = false)
     private String roomUuid;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 4)
     private String name;
 
     @Column(nullable = false)
@@ -57,6 +52,10 @@ public class Participant extends AbstractAggregateRoot<Participant> {
     private static void validateName(String name) {
         if (name == null) {
             throw new IllegalArgumentException("이름은 null일 수 없습니다");
+        }
+
+        if (name.length() > 4) {
+            throw new IllegalArgumentException("이름은 4글자 이하이어야 합니다");
         }
     }
 

--- a/src/test/java/com/dnd/modutime/participant/domain/ParticipantTest.java
+++ b/src/test/java/com/dnd/modutime/participant/domain/ParticipantTest.java
@@ -1,17 +1,24 @@
 package com.dnd.modutime.participant.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 public class ParticipantTest {
 
     @Test
     void 이름값이_null이면_예외가_발생한다() {
         assertThatThrownBy(() -> getParticipant(null, "1234"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"참여자동호", "참여자수진", "abcde"})
+    void 이름값이_4글자가_넘어가면_예외를_반환한다(String name) {
+        assertThatThrownBy(() -> getParticipant(name, "1234"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 


### PR DESCRIPTION
closed #24 


## 어떤 기능을 개발했나요?
* 회원가입시 참여자 이름 글자수를 4글자 이내로 제한하도록 설정했습니다

## 어떻게 해결했나요?


## 어떤 부분에 집중하여 리뷰해야 할까요?
* Participant 도메인 단의 테스트 확인과 이름 제한 validate를 거는 부분, db에 제약조건을 잘 설정했는지 점검부탁드립니다

## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.