### PR TITLE
chore: 배포환경의 yml을 사용하도록 github action 설정

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -45,17 +45,17 @@ jobs:
           remote_user: ubuntu
           remote_key: ${{ secrets.KEY }}
 
-      ## create application-database.yaml
-      - name: make application-database.yaml
+      ## create application-prod.yml
+      - name: make application-prod.yml
         run: |
-          ## create application-database.yaml
+          ## create application-prod.yml
           cd ./src/main/resources
           
-          # application-database.yaml 파일 생성
-          touch ./application-database.yaml
+          # application-database.yml 파일 생성
+          touch ./application-prod.yml
           
-          # GitHub-Actions 에서 설정한 값을 application-database.yaml 파일에 쓰기
-          echo "${{ secrets.DATABASE }}" >> ./application-database.yaml
+          # GitHub-Actions 에서 설정한 값을 application-prod.yml 파일에 쓰기
+          echo "${{ secrets.PROD_YML }}" >> ./application-prod.yml
         shell: bash
 
       ## gradle build

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar", "-Dspring.profiles.active=prod", "/app.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,18 +2,15 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true
     generate-ddl: true
   datasource:
-    url: jdbc:h2:mem:test6
-    username: sa
-  h2:
-    console:
-      enabled:
-        true
+    url: jdbc:mysql://localhost:3306/modutime?serverTimezone=Asia/Seoul
+    username: root
+    password:
 logging:
   level:
     org:


### PR DESCRIPTION
closed #40 


## 어떤 기능을 개발했나요?

- 로컬환경과 운영환경의 yml을 다르게 사용하도록 설정

## 어떻게 해결했나요?

- local에서 사용하는 datasource를 mysql를 사용하도록 수정
- github action secrets에 application-prod.yml 추가
- github action 에서 secrets의 yml을 사용해 빌드하도록 수정
- dockerfile에서 prod yml을 사용하도록 설정

## 어떤 부분에 집중하여 리뷰해야 할까요?


## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.