### PR TITLE
fix: 참여자 추가시 방의 제한 인원에 대한 검증 추가

### DIFF
--- a/src/main/java/com/dnd/modutime/core/participant/application/ParticipantCreateValidator.java
+++ b/src/main/java/com/dnd/modutime/core/participant/application/ParticipantCreateValidator.java
@@ -1,0 +1,6 @@
+package com.dnd.modutime.core.participant.application;
+
+public interface ParticipantCreateValidator {
+
+    void validate(String roomUuid);
+}

--- a/src/main/java/com/dnd/modutime/core/participant/application/ParticipantService.java
+++ b/src/main/java/com/dnd/modutime/core/participant/application/ParticipantService.java
@@ -16,8 +16,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class ParticipantService {
 
     private final ParticipantRepository participantRepository;
+    private final ParticipantCreateValidator participantCreateValidator;
 
     public void create(String roomUuid, String name, String password) {
+        participantCreateValidator.validate(roomUuid);
         Participant participant = new Participant(roomUuid, name, password);
         participantRepository.save(participant);
     }

--- a/src/main/java/com/dnd/modutime/core/room/application/RoomParticipantValidator.java
+++ b/src/main/java/com/dnd/modutime/core/room/application/RoomParticipantValidator.java
@@ -1,0 +1,34 @@
+package com.dnd.modutime.core.room.application;
+
+import com.dnd.modutime.core.participant.application.ParticipantCreateValidator;
+import com.dnd.modutime.core.participant.domain.Participant;
+import com.dnd.modutime.core.participant.repository.ParticipantRepository;
+import com.dnd.modutime.core.room.domain.Room;
+import com.dnd.modutime.core.room.repository.RoomRepository;
+import com.dnd.modutime.exception.NotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomParticipantValidator implements ParticipantCreateValidator {
+
+    private final RoomRepository roomRepository;
+    private final ParticipantRepository participantRepository;
+
+    @Override
+    public void validate(String roomUuid) {
+        Room room = getRoomByRoomUuid(roomUuid);
+        List<Participant> participants = participantRepository.findByRoomUuid(roomUuid);
+        Integer headCountOrNull = room.getHeadCountOrNull();
+        if (headCountOrNull != null && headCountOrNull == participants.size()) {
+            throw new IllegalArgumentException("방의 참여자를 초과해 참여자를 추가할 수 없습니다.");
+        }
+    }
+
+    private Room getRoomByRoomUuid(String roomUuid) {
+        return roomRepository.findByUuid(roomUuid)
+                .orElseThrow(() -> new NotFoundException("해당하는 방이 없습니다."));
+    }
+}

--- a/src/test/java/com/dnd/modutime/core/participant/integration/ParticipantIntegrationTest.java
+++ b/src/test/java/com/dnd/modutime/core/participant/integration/ParticipantIntegrationTest.java
@@ -3,7 +3,10 @@ package com.dnd.modutime.core.participant.integration;
 import static com.dnd.modutime.fixture.RoomRequestFixture.ROOM_UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 
+import com.dnd.modutime.core.participant.application.ParticipantCreateValidator;
 import com.dnd.modutime.core.participant.application.ParticipantService;
 import com.dnd.modutime.core.timeblock.application.ParticipantCreationEvent;
 import com.dnd.modutime.core.timeblock.domain.TimeBlock;
@@ -12,6 +15,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 
@@ -25,11 +29,15 @@ public class ParticipantIntegrationTest {
     @Autowired
     private TimeBlockRepository timeBlockRepository;
 
+    @MockBean
+    private ParticipantCreateValidator participantCreateValidator;
+
     @Autowired
     private ApplicationEvents events;
 
     @Test
     void 참여자가_생성되면_참여자의_TimeBlock이_생성된다() {
+        doNothing().when(participantCreateValidator).validate(any());
         participantService.create(ROOM_UUID, "참여자1", "1234");
         Optional<TimeBlock> actual = timeBlockRepository.findByRoomUuidAndParticipantName(ROOM_UUID, "참여자1");
         assertAll(

--- a/src/test/java/com/dnd/modutime/core/room/integration/RoomParticipantValidatorTest.java
+++ b/src/test/java/com/dnd/modutime/core/room/integration/RoomParticipantValidatorTest.java
@@ -1,0 +1,49 @@
+package com.dnd.modutime.core.room.integration;
+
+import static com.dnd.modutime.fixture.RoomFixture.getRoomByHeadCount;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.dnd.modutime.core.participant.domain.Participant;
+import com.dnd.modutime.core.participant.repository.ParticipantRepository;
+import com.dnd.modutime.core.room.application.RoomParticipantValidator;
+import com.dnd.modutime.core.room.domain.Room;
+import com.dnd.modutime.core.room.repository.RoomRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class RoomParticipantValidatorTest {
+
+    @Autowired
+    private RoomParticipantValidator roomParticipantValidator;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Test
+    void headCount가_없을경우_예외가_발생하지_않는다() {
+        Room room = getRoomByHeadCount(null);
+        Room savedRoom = roomRepository.save(room);
+        assertDoesNotThrow(() -> roomParticipantValidator.validate(savedRoom.getUuid()));
+    }
+
+    @Test
+    void headCount가_방의_참여자의_수가_같을경우_예외가_발생한다() {
+        Room room = getRoomByHeadCount(3);
+        Room savedRoom = roomRepository.save(room);
+        세명을_저장한다(savedRoom.getUuid());
+        assertThatThrownBy(() -> roomParticipantValidator.validate(savedRoom.getUuid()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private void 세명을_저장한다(String roomUUid) {
+        participantRepository.save(new Participant(roomUUid, "김동호", "1234"));
+        participantRepository.save(new Participant(roomUUid, "이수진", "1234"));
+        participantRepository.save(new Participant(roomUUid, "이세희", "1234"));
+    }
+}

--- a/src/test/java/com/dnd/modutime/core/timetable/integration/TimeTableIntegrationTest.java
+++ b/src/test/java/com/dnd/modutime/core/timetable/integration/TimeTableIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
+import com.dnd.modutime.core.participant.application.ParticipantCreateValidator;
 import com.dnd.modutime.core.timeblock.application.request.TimeReplaceRequest;
 import com.dnd.modutime.core.participant.application.ParticipantService;
 import com.dnd.modutime.core.timeblock.application.TimeBlockService;
@@ -41,11 +42,15 @@ public class TimeTableIntegrationTest {
     @MockBean
     private TimeTableUpdateService timeTableUpdateService;
 
+    @MockBean
+    private ParticipantCreateValidator participantCreateValidator;
+
     @Autowired
     private ApplicationEvents events;
 
     @Test
     void 참여자가_가능한_시간을_교체하면_TimeTable을_수정한다() {
+        doNothing().when(participantCreateValidator).validate(any());
         participantService.create(ROOM_UUID, "참여자1", "1234");
         doNothing().when(timeReplaceValidator).validate(any(), any());
         TimeReplaceRequest timeReplaceRequest = new TimeReplaceRequest("참여자1", true, List.of(LocalDateTime.of(_2023_02_10, _12_00), LocalDateTime.of(_2023_02_10, _13_00)));


### PR DESCRIPTION
closed #52 


## 어떤 기능을 개발했나요?

참여자 추가시 방의 제한 인원에 대한 검증 추가

## 어떻게 해결했나요?

- ParticipantService에서 ParticipantCreateValidator interface를 추가했습니다.
- 구현체는 room 쪽에 두어서 room의 제한 인원을 확인할 수 있도록 수정했습니다.

## 어떤 부분에 집중하여 리뷰해야 할까요?


## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.