### PR TITLE
fix: 방 생성시 date를 시간순으로 저장

### DIFF
--- a/src/main/java/com/dnd/modutime/core/room/domain/Room.java
+++ b/src/main/java/com/dnd/modutime/core/room/domain/Room.java
@@ -80,6 +80,8 @@ public class Room extends AbstractAggregateRoot<Room> {
         this.headCount = headCount;
         this.uuid = UUID.randomUUID().toString();
         this.deadLine = deadLine;
+
+        sortByDate(roomDates);
     }
 
     private void validateTitle(String title) {
@@ -120,11 +122,9 @@ public class Room extends AbstractAggregateRoot<Room> {
         if (roomDates.isEmpty()) {
             throw new IllegalArgumentException("날짜는 최소 1개이상 존재해야 합니다.");
         }
-
-        sortingByDate(roomDates);
     }
 
-    private void sortingByDate(List<RoomDate> roomDates) {
+    private void sortByDate(List<RoomDate> roomDates) {
         Collections.sort(roomDates, Comparator.comparing(RoomDate::getDate));
     }
 

--- a/src/main/java/com/dnd/modutime/core/room/domain/Room.java
+++ b/src/main/java/com/dnd/modutime/core/room/domain/Room.java
@@ -2,11 +2,13 @@ package com.dnd.modutime.core.room.domain;
 
 import static javax.persistence.GenerationType.IDENTITY;
 
-import com.dnd.modutime.util.TimeProvider;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -16,9 +18,13 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
+
+import org.springframework.data.domain.AbstractAggregateRoot;
+
+import com.dnd.modutime.util.TimeProvider;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.AbstractAggregateRoot;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -114,6 +120,12 @@ public class Room extends AbstractAggregateRoot<Room> {
         if (roomDates.isEmpty()) {
             throw new IllegalArgumentException("날짜는 최소 1개이상 존재해야 합니다.");
         }
+
+        sortingByDate(roomDates);
+    }
+
+    private void sortingByDate(List<RoomDate> roomDates) {
+        Collections.sort(roomDates, Comparator.comparing(RoomDate::getDate));
     }
 
     private void validateDeadLine(LocalDateTime deadLine,

--- a/src/test/java/com/dnd/modutime/core/room/domain/RoomTest.java
+++ b/src/test/java/com/dnd/modutime/core/room/domain/RoomTest.java
@@ -18,12 +18,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.dnd.modutime.util.FakeTimeProvider;
-import com.dnd.modutime.core.room.domain.Room;
-import com.dnd.modutime.core.room.domain.RoomDate;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
+
+import com.dnd.modutime.util.FakeTimeProvider;
 
 public class RoomTest {
 
@@ -121,13 +122,19 @@ public class RoomTest {
 
     @Test
     void 들어온_날짜들이_방의_날짜들안에_모두_포함되면_true를_반환한다() {
-        Room room = getRoomByRoomDates(List.of(new RoomDate(_2023_02_09), new RoomDate(_2023_02_10)));
+        List<RoomDate> roomDates = new ArrayList<>();
+        roomDates.add(new RoomDate(_2023_02_09));
+        roomDates.add(new RoomDate(_2023_02_10));
+        Room room = getRoomByRoomDates(roomDates);
         assertThat(room.containsAllDates(List.of(new RoomDate(_2023_02_09), new RoomDate(_2023_02_10)))).isTrue();
     }
 
     @Test
     void 들어온_날짜들중_하나라도_방의_날짜들안에_모두_포함되지않으면_false를_반환한다() {
-        Room room = getRoomByRoomDates(List.of(new RoomDate(_2023_02_09), new RoomDate(_2023_02_10)));
+        List<RoomDate> roomDates = new ArrayList<>();
+        roomDates.add(new RoomDate(_2023_02_09));
+        roomDates.add(new RoomDate(_2023_02_10));
+        Room room = getRoomByRoomDates(roomDates);
         assertThat(room.containsAllDates(List.of(new RoomDate(_2023_02_08), new RoomDate(_2023_02_09)))).isFalse();
     }
 
@@ -159,5 +166,20 @@ public class RoomTest {
     void 끝나는시간의_이후_시간이_들어오면_예외가_발생한다() {
         Room room = getRoomByStartEndTime(_12_00, _13_00);
         assertThat(room.includeTime(_14_00)).isFalse();
+    }
+
+    @Test
+    void 방_생성시_dates는_날짜순으로_저장된다() {
+        List<RoomDate> roomDates = new ArrayList<>();
+        roomDates.add(new RoomDate(_2023_02_10));
+        roomDates.add(new RoomDate(_2023_02_09));
+        roomDates.add(new RoomDate(_2023_02_08));
+        Room room = getRoomByRoomDates(roomDates);
+        List<RoomDate> getRoomDates = room.getRoomDates();
+        assertAll(
+            () -> assertThat(getRoomDates.get(0).getDate()).isEqualTo(_2023_02_08),
+            () -> assertThat(getRoomDates.get(1).getDate()).isEqualTo(_2023_02_09),
+            () -> assertThat(getRoomDates.get(2).getDate()).isEqualTo(_2023_02_10)
+        );
     }
 }

--- a/src/test/java/com/dnd/modutime/core/room/integration/RoomIntegrationTest.java
+++ b/src/test/java/com/dnd/modutime/core/room/integration/RoomIntegrationTest.java
@@ -1,29 +1,21 @@
 package com.dnd.modutime.core.room.integration;
 
+import static com.dnd.modutime.fixture.RoomFixture.getRoom;
 import static com.dnd.modutime.fixture.RoomRequestFixture.getRoomRequest;
+import static com.dnd.modutime.fixture.TimeFixture._11_00;
 import static com.dnd.modutime.fixture.TimeFixture._12_00;
 import static com.dnd.modutime.fixture.TimeFixture._13_00;
+import static com.dnd.modutime.fixture.TimeFixture._2023_02_08;
+import static com.dnd.modutime.fixture.TimeFixture._2023_02_09;
 import static com.dnd.modutime.fixture.TimeFixture._2023_02_10;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
-import com.dnd.modutime.config.TimeConfiguration;
-import com.dnd.modutime.core.room.application.request.RoomRequest;
-import com.dnd.modutime.core.timeblock.application.request.TimeReplaceRequest;
-import com.dnd.modutime.core.timetable.application.response.AvailableTimeInfo;
-import com.dnd.modutime.core.room.application.response.RoomCreationResponse;
-import com.dnd.modutime.core.timetable.application.response.TimeAndCountPerDate;
-import com.dnd.modutime.core.timetable.application.response.TimeTableResponse;
-import com.dnd.modutime.core.participant.application.ParticipantService;
-import com.dnd.modutime.core.room.application.RoomService;
-import com.dnd.modutime.core.timeblock.application.TimeBlockService;
-import com.dnd.modutime.core.timeblock.application.TimeReplaceValidator;
-import com.dnd.modutime.core.timeblock.domain.TimeBlockReplaceEvent;
-import com.dnd.modutime.core.timetable.application.TimeTableService;
 import java.time.LocalDateTime;
 import java.util.List;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +24,23 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
+
+import com.dnd.modutime.config.TimeConfiguration;
+import com.dnd.modutime.core.participant.application.ParticipantService;
+import com.dnd.modutime.core.room.application.RoomService;
+import com.dnd.modutime.core.room.application.request.RoomRequest;
+import com.dnd.modutime.core.room.application.response.RoomCreationResponse;
+import com.dnd.modutime.core.room.domain.Room;
+import com.dnd.modutime.core.room.domain.RoomDate;
+import com.dnd.modutime.core.room.repository.RoomRepository;
+import com.dnd.modutime.core.timeblock.application.TimeBlockService;
+import com.dnd.modutime.core.timeblock.application.TimeReplaceValidator;
+import com.dnd.modutime.core.timeblock.application.request.TimeReplaceRequest;
+import com.dnd.modutime.core.timeblock.domain.TimeBlockReplaceEvent;
+import com.dnd.modutime.core.timetable.application.TimeTableService;
+import com.dnd.modutime.core.timetable.application.response.AvailableTimeInfo;
+import com.dnd.modutime.core.timetable.application.response.TimeAndCountPerDate;
+import com.dnd.modutime.core.timetable.application.response.TimeTableResponse;
 
 @Import(TimeConfiguration.class)
 @RecordApplicationEvents
@@ -56,11 +65,32 @@ public class RoomIntegrationTest {
     @Autowired
     private ApplicationEvents events;
 
+    @Autowired
+    private RoomRepository roomRepository;
+
     @Test
     void 방을_생성한다() {
         RoomRequest roomRequest = getRoomRequest();
         RoomCreationResponse roomCreationResponse = roomService.create(roomRequest);
         assertThat(roomCreationResponse.getUuid()).isNotNull();
+    }
+
+    @Test
+    void 방_생성시_date는_시간순으로_저장한다() {
+
+        // given
+        Room room = getRoom(_11_00, _13_00, List.of(_2023_02_10, _2023_02_09, _2023_02_08), 2);
+        Room savedRoom = roomRepository.save(room);
+
+        // when
+        List<RoomDate> roomDates = savedRoom.getRoomDates();
+
+        // then
+        assertAll(
+            () -> assertThat(roomDates.get(0).getDate()).isEqualTo(_2023_02_08),
+            () -> assertThat(roomDates.get(1).getDate()).isEqualTo(_2023_02_09),
+            () -> assertThat(roomDates.get(2).getDate()).isEqualTo(_2023_02_10)
+        );
     }
 
     // TODO: 위치 변경 필요


### PR DESCRIPTION
closed #60 


## 어떤 기능을 개발했나요?
현재 상황 - 방 정보 조회 시 date가 무작위로 조회는데, 이를 정렬된 값을 반환하도록 하고자 합니다

## 어떻게 해결했나요?
방 생성시에 입력받은 date를 정렬을 먼저 시킨 후 저장하도록 하였습니다

## 어떤 부분에 집중하여 리뷰해야 할까요?


## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.