### PR TITLE
fix: 시간을 등록하지 않은 참여자를 조회할때 빈 리스트를 반환하도록 수정

### DIFF
--- a/src/main/java/com/dnd/modutime/core/timeblock/application/TimeBlockService.java
+++ b/src/main/java/com/dnd/modutime/core/timeblock/application/TimeBlockService.java
@@ -1,13 +1,13 @@
 package com.dnd.modutime.core.timeblock.application;
 
+import com.dnd.modutime.core.timeblock.application.request.TimeReplaceRequest;
+import com.dnd.modutime.core.timeblock.application.response.TimeBlockResponse;
 import com.dnd.modutime.core.timeblock.domain.AvailableDateTime;
 import com.dnd.modutime.core.timeblock.domain.TimeBlock;
 import com.dnd.modutime.core.timeblock.repository.AvailableDateTimeRepository;
 import com.dnd.modutime.core.timeblock.repository.TimeBlockRepository;
 import com.dnd.modutime.core.timeblock.util.DateTimeToAvailableDateTimeConvertor;
 import com.dnd.modutime.core.timeblock.util.DateTimeToAvailableDateTimeConvertorFactory;
-import com.dnd.modutime.core.timeblock.application.request.TimeReplaceRequest;
-import com.dnd.modutime.core.timeblock.application.response.TimeBlockResponse;
 import com.dnd.modutime.exception.NotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -44,8 +44,16 @@ public class TimeBlockService {
     }
 
     public TimeBlockResponse getTimeBlock(String roomUuid, String name) {
-        TimeBlock timeBlock = getTimeBlockByRoomUuidAndParticipantName(roomUuid, name);
-        List<AvailableDateTime> availableDateTimes = availableDateTimeRepository.findByTimeBlockId(timeBlock.getId());
-        return TimeBlockResponse.of(timeBlock.getParticipantName(), availableDateTimes);
+        validateRoomExist(roomUuid);
+        return timeBlockRepository.findByRoomUuidAndParticipantName(roomUuid, name)
+                .map(timeBlock -> TimeBlockResponse.of(timeBlock.getParticipantName(),
+                        availableDateTimeRepository.findByTimeBlockId(timeBlock.getId())))
+                .orElse(TimeBlockResponse.of(name, List.of()));
+    }
+
+    private void validateRoomExist(String roomUuid) {
+        if (!timeBlockRepository.existsByRoomUuid(roomUuid)) {
+            throw new NotFoundException("해당하는 TimeBlock을 찾을 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/dnd/modutime/core/timeblock/repository/TimeBlockRepository.java
+++ b/src/main/java/com/dnd/modutime/core/timeblock/repository/TimeBlockRepository.java
@@ -10,4 +10,6 @@ public interface TimeBlockRepository extends JpaRepository<TimeBlock, Long> {
     Optional<TimeBlock> findByRoomUuidAndParticipantName(String roomUuid, String participantName);
 
     List<TimeBlock> findByRoomUuid(String roomUuid);
+
+    boolean existsByRoomUuid(String roomUuid);
 }


### PR DESCRIPTION
closed #59 


## 어떤 기능을 개발했나요?

시간을 등록하지 않은 참여자를 조회할떼 빈 리스트를 반환하도록 수정하였습니다.

## 어떻게 해결했나요?

이슈상황 : 해당 방의 참여자여도 timeBlock은 존재하지 않기때문에 NotFound 예외가 발생하고 있었습니다.

그래서 아래의 방식으로 해결했습니다.

1. 해당 방이 존재하는지 먼저 확인
2. `findByRoomUuidAndParticipantName(roomUuid, name)` 메서드로 Optional로 조회
   2.1. 데이터가 존재한다면 해당 데이터로 response를 만들기
   2.2. 데이터가 존재하지 않는다면 빈 리스트로 response를 만들기

### 방이 존재하는지 먼저 검증하는 이유

- `findByRoomUuidAndParticipantName`가 `(roomUuid, name)` 파라미터 두개로 조회중
- 그래서 Not Found 예외가 발생하는 조건이 `roomUuid, name` 두가지 포인트
- 먼저 `roomUuid`의 값이 올바른지 검사하고 그 다음에 `(roomUuid, name)`으로 조회해서 예외가 name 때문에만 발생할 수 있는 것을 확인가능


## 어떤 부분에 집중하여 리뷰해야 할까요?

- 이 외에 예외가 발생할 수 있는 상황을 확인해주세요.

## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.