### PR TITLE
fix: 날짜만 있는 방의 시간을 지정하지 않고 시간교체시 예외가 발생하지 않도록 수정

### DIFF
--- a/src/main/java/com/dnd/modutime/core/room/application/RoomTimeValidator.java
+++ b/src/main/java/com/dnd/modutime/core/room/application/RoomTimeValidator.java
@@ -47,6 +47,9 @@ public class RoomTimeValidator implements TimeReplaceValidator {
     }
 
     private void validateStartAndEndTime(Room room, List<AvailableDateTime> availableDateTimes) {
+        if (availableDateTimes.isEmpty()) {
+            return;
+        }
         if (room.hasStartAndEndTime() && !hasTime(availableDateTimes)) {
             throw new IllegalArgumentException("해당 방에는 시간 값이 필요합니다.");
         }

--- a/src/test/java/com/dnd/modutime/core/room/integration/RoomTimeValidatorTest.java
+++ b/src/test/java/com/dnd/modutime/core/room/integration/RoomTimeValidatorTest.java
@@ -73,6 +73,13 @@ class RoomTimeValidatorTest {
     }
 
     @Test
+    void 시작과_끝나는_시간이_없는_방에_빈_AvailableDateTime_List를_넘겨주면_예외가_발생하지_않는다() {
+        Room room = getRoomByStartEndTime(null, null);
+        Room savedRoom = roomRepository.save(room);
+        assertDoesNotThrow(() -> roomTimeValidator.validate(savedRoom.getUuid(), List.of()));
+    }
+
+    @Test
     void 현재시간이_방의_데드라인이후인경우_예외가_발생한다() {
         Room room = getRoomByStartEndTime(_12_00, _13_00);
         Room savedRoom = roomRepository.save(room);


### PR DESCRIPTION
closed #64 


## 어떤 기능을 개발했나요?

날짜만 있는 방의 시간을 지정하지 않고 시간교체시 예외가 발생하지 않도록 수정했습니다.

## 어떻게 해결했나요?

날짜만 있는 방의 시간교체시 빈 리스트이면 아무것도 하지 않고 return 하도록 수정했습니다.

## 어떤 부분에 집중하여 리뷰해야 할까요?


## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.