### PR TITLE
fix: 실시간 등록 현황 API에서 count 에러를 해결

### DIFF
--- a/src/main/java/com/dnd/modutime/core/adjustresult/domain/CandidateDateTime.java
+++ b/src/main/java/com/dnd/modutime/core/adjustresult/domain/CandidateDateTime.java
@@ -43,7 +43,7 @@ public class CandidateDateTime {
     @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, fetch = FetchType.EAGER)
     @JoinColumn(
             name = "candidate_date_time_id", nullable = false, updatable = false,
-            foreignKey = @ForeignKey(name = "fk_candidate_date_time_participant_name_candidate_date_time_id_ref_candidate_date_time_id")
+            foreignKey = @ForeignKey(name = "fk_cdt_participant_name_cdt_id_ref_cdt_id")
     )
     private List<CandidateDateTimeParticipantName> participantNames;
 

--- a/src/main/java/com/dnd/modutime/core/timeblock/domain/AvailableDateTime.java
+++ b/src/main/java/com/dnd/modutime/core/timeblock/domain/AvailableDateTime.java
@@ -33,7 +33,7 @@ public class AvailableDateTime {
     @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, fetch = FetchType.EAGER)
     @JoinColumn(
             name = "available_date_time_id", nullable = false, updatable = false,
-            foreignKey = @ForeignKey(name = "fk_available_time_available_date_time_id_ref_available_date_time_id")
+            foreignKey = @ForeignKey(name = "fk_at_adt_id_ref_adt_id")
     )
     private List<AvailableTime> times;
 

--- a/src/main/java/com/dnd/modutime/core/timetable/application/TimeTableUpdateService.java
+++ b/src/main/java/com/dnd/modutime/core/timetable/application/TimeTableUpdateService.java
@@ -1,7 +1,9 @@
 package com.dnd.modutime.core.timetable.application;
 
+import com.dnd.modutime.core.timetable.domain.TimeTableReplaceEvent;
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +23,7 @@ public class TimeTableUpdateService {
 
     private final TimeTableRepository timeTableRepository;
     private final TimeInfoParticipantNameRepository timeInfoParticipantNameRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     // TODO: test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -36,6 +39,7 @@ public class TimeTableUpdateService {
 
         timeTable.addParticipantName(event.getNewAvailableDateTimes(), event.getParticipantName());
         timeTableRepository.save(timeTable);
+        eventPublisher.publishEvent(new TimeTableReplaceEvent(event.getRoomUuid(), timeTable.getDateInfos()));
     }
 
     private TimeTable getTimeTableByRoomUuid(String roomUuid) {

--- a/src/main/java/com/dnd/modutime/core/timetable/application/TimeTableUpdateService.java
+++ b/src/main/java/com/dnd/modutime/core/timetable/application/TimeTableUpdateService.java
@@ -1,16 +1,19 @@
 package com.dnd.modutime.core.timetable.application;
 
-import com.dnd.modutime.core.timetable.domain.TimeTable;
-import com.dnd.modutime.core.timetable.repository.TimeInfoParticipantNameRepository;
-import com.dnd.modutime.core.timetable.repository.TimeTableRepository;
-import com.dnd.modutime.exception.NotFoundException;
-import com.dnd.modutime.core.timeblock.domain.TimeBlockReplaceEvent;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.dnd.modutime.core.timeblock.domain.TimeBlockReplaceEvent;
+import com.dnd.modutime.core.timetable.domain.TimeTable;
+import com.dnd.modutime.core.timetable.repository.TimeInfoParticipantNameRepository;
+import com.dnd.modutime.core.timetable.repository.TimeTableRepository;
+import com.dnd.modutime.exception.NotFoundException;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -25,12 +28,13 @@ public class TimeTableUpdateService {
     public void update(TimeBlockReplaceEvent event) {
         TimeTable timeTable = getTimeTableByRoomUuid(event.getRoomUuid());
         List<Long> timeInfoIds = timeTable.getTimeInfoIdsByAvailableDateTimes(event.getOldAvailableDateTimes());
+
+        timeTable.removeParticipantName(event.getOldAvailableDateTimes(), event.getParticipantName());
         for (Long timeInfoId : timeInfoIds) {
             timeInfoParticipantNameRepository.deleteByTimeInfoIdAndName(timeInfoId, event.getParticipantName());
         }
-        timeTable.updateParticipantName(event.getOldAvailableDateTimes(),
-                event.getNewAvailableDateTimes(),
-                event.getParticipantName());
+
+        timeTable.addParticipantName(event.getNewAvailableDateTimes(), event.getParticipantName());
         timeTableRepository.save(timeTable);
     }
 

--- a/src/main/java/com/dnd/modutime/core/timetable/domain/DateInfo.java
+++ b/src/main/java/com/dnd/modutime/core/timetable/domain/DateInfo.java
@@ -59,7 +59,7 @@ public class DateInfo {
         if (!this.date.isEqual(date)) {
             return List.of();
         }
-        if (timesOrNull.isEmpty()) {
+        if (timesOrNull == null) {
             validateTimeInfoIsEmpty();
             return List.of(timeInfos.get(0).getId());
         }
@@ -79,7 +79,7 @@ public class DateInfo {
             return;
         }
         List<AvailableTime> timesOrNull = availableDateTime.getTimesOrNull();
-        if (timesOrNull.isEmpty()) {
+        if (timesOrNull == null) {
             validateTimeInfoIsEmpty();
             TimeInfo timeInfo = timeInfos.get(0);
             timeInfo.removeParticipantName(participantName);

--- a/src/main/java/com/dnd/modutime/core/timetable/domain/DateInfo.java
+++ b/src/main/java/com/dnd/modutime/core/timetable/domain/DateInfo.java
@@ -1,11 +1,10 @@
 package com.dnd.modutime.core.timetable.domain;
 
-import com.dnd.modutime.core.timeblock.domain.AvailableDateTime;
-import com.dnd.modutime.core.timeblock.domain.AvailableTime;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,6 +16,10 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+
+import com.dnd.modutime.core.timeblock.domain.AvailableDateTime;
+import com.dnd.modutime.core.timeblock.domain.AvailableTime;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -37,7 +40,7 @@ public class DateInfo {
 
     @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, fetch = FetchType.EAGER)
     @JoinColumn(
-            name = "time_table_id", nullable = false, updatable = false,
+            name = "date_info_id", nullable = false, updatable = false,
             foreignKey = @ForeignKey(name = "fk_time_info_date_info_id_ref_date_info_id")
     )
     private List<TimeInfo> timeInfos;
@@ -56,7 +59,7 @@ public class DateInfo {
         if (!this.date.isEqual(date)) {
             return List.of();
         }
-        if (timesOrNull == null) {
+        if (timesOrNull.isEmpty()) {
             validateTimeInfoIsEmpty();
             return List.of(timeInfos.get(0).getId());
         }
@@ -76,7 +79,7 @@ public class DateInfo {
             return;
         }
         List<AvailableTime> timesOrNull = availableDateTime.getTimesOrNull();
-        if (timesOrNull == null) {
+        if (timesOrNull.isEmpty()) {
             validateTimeInfoIsEmpty();
             TimeInfo timeInfo = timeInfos.get(0);
             timeInfo.removeParticipantName(participantName);

--- a/src/main/java/com/dnd/modutime/core/timetable/domain/TimeTable.java
+++ b/src/main/java/com/dnd/modutime/core/timetable/domain/TimeTable.java
@@ -1,10 +1,9 @@
 package com.dnd.modutime.core.timetable.domain;
 
-import com.dnd.modutime.core.adjustresult.application.DateTimeInfoDto;
-import com.dnd.modutime.core.timeblock.domain.AvailableDateTime;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,9 +12,14 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+
+import org.springframework.data.domain.AbstractAggregateRoot;
+
+import com.dnd.modutime.core.adjustresult.application.DateTimeInfoDto;
+import com.dnd.modutime.core.timeblock.domain.AvailableDateTime;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.AbstractAggregateRoot;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -45,13 +49,13 @@ public class TimeTable extends AbstractAggregateRoot<TimeTable> {
                                       String participantName) {
         removeParticipantName(oldAvailableDateTimes, participantName);
         addParticipantName(newAvailableDateTimes, participantName);
-        registerEvent(new TimeTableReplaceEvent(roomUuid, dateInfos));
+        registerEvent(new TimeTableReplaceEvent(roomUuid, dateInfos)); // TODO
     }
 
     public List<Long> getTimeInfoIdsByAvailableDateTimes(List<AvailableDateTime> availableDateTimes) {
         List<Long> timeInfoIds = new ArrayList<>();
-        for (AvailableDateTime availableDateTime : availableDateTimes) {
-            for (DateInfo dateInfo : dateInfos) {
+        for (DateInfo dateInfo : dateInfos) {
+            for (AvailableDateTime availableDateTime : availableDateTimes) {
                 timeInfoIds.addAll(dateInfo.getTimeInfoIdsByAvailableDateTime(availableDateTime));
             }
         }
@@ -70,7 +74,7 @@ public class TimeTable extends AbstractAggregateRoot<TimeTable> {
         );
     }
 
-    private void removeParticipantName(List<AvailableDateTime> availableDateTimes, String participantName) {
+    public void removeParticipantName(List<AvailableDateTime> availableDateTimes, String participantName) {
         availableDateTimes.forEach(
                 availableDateTime -> dateInfos.forEach(
                         dateInfo -> dateInfo.removeParticipantNameIfSameDate(availableDateTime, participantName)
@@ -78,7 +82,7 @@ public class TimeTable extends AbstractAggregateRoot<TimeTable> {
         );
     }
 
-    private void addParticipantName(List<AvailableDateTime> availableDateTimes, String participantName) {
+    public void addParticipantName(List<AvailableDateTime> availableDateTimes, String participantName) {
         availableDateTimes.forEach(
                 availableDateTime -> dateInfos.forEach(
                         dateInfo -> dateInfo.addParticipantNameIfSameDate(availableDateTime, participantName)

--- a/src/main/java/com/dnd/modutime/core/timetable/repository/TimeInfoParticipantNameRepository.java
+++ b/src/main/java/com/dnd/modutime/core/timetable/repository/TimeInfoParticipantNameRepository.java
@@ -1,9 +1,10 @@
 package com.dnd.modutime.core.timetable.repository;
 
-import com.dnd.modutime.core.timetable.domain.TimeInfoParticipantName;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dnd.modutime.core.timetable.domain.TimeInfoParticipantName;
 
 public interface TimeInfoParticipantNameRepository extends JpaRepository<TimeInfoParticipantName, Long> {
 
-    void deleteByTimeInfoIdAndName(Long timeInfoIds, String name);
+    void deleteByTimeInfoIdAndName(Long timeInfoId, String name);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/com/dnd/modutime/core/timetable/domain/DateInfoTest.java
+++ b/src/test/java/com/dnd/modutime/core/timetable/domain/DateInfoTest.java
@@ -44,7 +44,7 @@ public class DateInfoTest {
                 null), "참여자1");
 
         dateInfo.removeParticipantNameIfSameDate(new AvailableDateTime(new TimeBlock(ROOM_UUID, "참여자1"), _2023_02_10,
-                List.of()), "참여자1");
+                null), "참여자1");
         TimeInfo timeInfo = dateInfo.getTimeInfos().get(0);
         assertThat(timeInfo.getTimeInfoParticipantNames().stream()
                 .map(TimeInfoParticipantName::getName)

--- a/src/test/java/com/dnd/modutime/core/timetable/domain/DateInfoTest.java
+++ b/src/test/java/com/dnd/modutime/core/timetable/domain/DateInfoTest.java
@@ -12,15 +12,14 @@ import static com.dnd.modutime.fixture.TimeTableFixture.getTimeInfo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
 import com.dnd.modutime.core.timeblock.domain.AvailableDateTime;
 import com.dnd.modutime.core.timeblock.domain.AvailableTime;
 import com.dnd.modutime.core.timeblock.domain.TimeBlock;
-import com.dnd.modutime.core.timetable.domain.DateInfo;
-import com.dnd.modutime.core.timetable.domain.TimeInfo;
-import com.dnd.modutime.core.timetable.domain.TimeInfoParticipantName;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.Test;
 
 public class DateInfoTest {
 
@@ -45,7 +44,7 @@ public class DateInfoTest {
                 null), "참여자1");
 
         dateInfo.removeParticipantNameIfSameDate(new AvailableDateTime(new TimeBlock(ROOM_UUID, "참여자1"), _2023_02_10,
-                null), "참여자1");
+                List.of()), "참여자1");
         TimeInfo timeInfo = dateInfo.getTimeInfos().get(0);
         assertThat(timeInfo.getTimeInfoParticipantNames().stream()
                 .map(TimeInfoParticipantName::getName)


### PR DESCRIPTION
closed #62 


## 어떤 기능을 개발했나요?
정확히 말해서 참여자가 시간 교체시, TimeTable에 있는 participant에 참여자의 정보가 제대로 업데이트 되지 않아 실시간 등록 현황 API에서 count 값이 제대로 counting이 되지 않았습니다.
그래서 교체 시 TimeTable이 변경되는 부분에서 에러를 찾아 해결해, 실시간 등록 현황 조회 시 count 값이 제대로 반환하도록 하였습니다.

## 어떻게 해결했나요?
가장 문제가 되었던 부분은 다음과 같습니다.
```java
        for (Long timeInfoId : timeInfoIds) {
            timeInfoParticipantNameRepository.deleteByTimeInfoIdAndName(timeInfoId, event.getParticipantName());
        }
        timeTable.updateParticipantName(event.getOldAvailableDateTimes(),
                event.getNewAvailableDateTimes(),
                event.getParticipantName());
        timeTableRepository.save(timeTable);
```
이 부분이 시간교체시 TimeTable의 교체 로직에 해당합니다.
쿼리를 확인한 결과 delete쿼리가 제대로 나가지 않았습니다
즉 counting이 제대로 되지 않았던 이유는, 삭제되어야하는 엔티티가 제대로 삭제 되지 않았기 때문입니다
자세히 보니,
JPA에서 삭제를 먼저 수행하고, 그 다음에 도메인에서 삭제와 저장을 수행하고 다시 JPA에서 저장을 수행합니다. 찾아보니 이럴 경우 복수개의 엔티티를 삭제 시 문제가 발생할 수 있다고 합니다.
실제로도 복수 개의 데이터가 삭제되어야하는데, 전부 삭제가 되지 않는 경우도 있었습니다.
데이터 무결성에 문제가 생겼던 것으로 생각됩니다.

이렇게 삭제와 저장이 동시에 수행되어야하는 경우
작업 순서는 다음과 같이 처리되어야합니다

```
- 삭제할 엔티티와 관련된 엔티티들의 관계를 먼저 제거
- 해당 엔티티를 JPA를 통해 삭제
- 추가할 엔티티를 생성하고, 관련된 엔티티들의 관계를 설정
- 해당 엔티티를 JPA를 통해 저장
```

구글링을 통해 얻은 추가적인 내용입니다. 참고하면 좋을 것 같습니다.

```
삭제와 저장이 동시에 수행되는 경우
먼저 삭제 작업을 처리한 후에 추가 작업을 처리하는 것이 좋습니다. 그리고 삭제와 추가 작업은 서로 다른 트랜잭션으로 처리하는 것이 안전합니다. 특히, 삭제 작업을 먼저 처리하면서 엔티티의 관계를 제거하는 것이 중요합니다. 이것이 제대로 처리되지 않으면 데이터베이스 무결성에 문제가 발생할 수 있습니다.
```

다음은 변경된 부분입니다

```java
        timeTable.removeParticipantName(event.getOldAvailableDateTimes(), event.getParticipantName());
        for (Long timeInfoId : timeInfoIds) {
            timeInfoParticipantNameRepository.deleteByTimeInfoIdAndName(timeInfoId, event.getParticipantName());
        }

        timeTable.addParticipantName(event.getNewAvailableDateTimes(), event.getParticipantName());
        timeTableRepository.save(timeTable);
```

또한, availableTimes를 가져오는 부분에도 문제가 있었습니다.
삭제할 때 즉, 기존에 존재하는 availableTimes를 가져오는 경우에는 isEmpty() 로 값의 유무를 확인해야하고,
저장할 때 즉, 새로운 availableTimes를 가져오는 경우에는 is null 로 값의 유무를 확인해야 했습니다.
왜냐하면 이미 값이 존재하는 경우는 인스턴스가 생성되어 있기 때문입니다
해당 고친 부분은 해당 부분의 테스트도 수정해 놓았습니다


## 어떤 부분에 집중하여 리뷰해야 할까요?

위 설명을 참고하면 될 것 같습니다!


## (option) 이 부분은 주의해 주세요.

# 중요 !!
- 운영 배포될 때 joinColumn 바뀐 것 때문에 동작을 안할 수 있습니다 !
- 어차피 테스트용으로 사용하고 있었어서, 운영디비를 한번 날렸다가 다시 했으면 좋겠는데 가능할까요?


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.