### PR TITLE
refactor: 방 정보 조회시 날짜가 정렬되어서 반환되도록 수정

### DIFF
--- a/src/main/java/com/dnd/modutime/core/room/application/RoomService.java
+++ b/src/main/java/com/dnd/modutime/core/room/application/RoomService.java
@@ -12,6 +12,7 @@ import com.dnd.modutime.exception.NotFoundException;
 import com.dnd.modutime.core.participant.repository.ParticipantRepository;
 import com.dnd.modutime.util.TimeProvider;
 import com.dnd.modutime.util.Timer;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -69,14 +70,17 @@ public class RoomService {
     public RoomInfoResponse getInfo(String roomUuid) {
         Room room = getByUuid(roomUuid);
         List<Participant> participants = participantRepository.findByRoomUuid(roomUuid);
+        List<LocalDate> roomDates = room.getRoomDates().stream()
+                .map(RoomDate::getDate)
+                .collect(Collectors.toList());
         return new RoomInfoResponse(room.getTitle(),
                 room.getDeadLineOrNull(),
                 room.getHeadCountOrNull(),
                 participants.stream()
                         .map(Participant::getName)
                         .collect(Collectors.toList()),
-                room.getRoomDates().stream()
-                        .map(RoomDate::getDate)
+                roomDates.stream()
+                        .sorted()
                         .collect(Collectors.toList()),
                 room.getStartTimeOrNull(),
                 room.getEndTimeOrNull());

--- a/src/test/java/com/dnd/modutime/core/room/integration/RoomIntegrationTest.java
+++ b/src/test/java/com/dnd/modutime/core/room/integration/RoomIntegrationTest.java
@@ -3,6 +3,8 @@ package com.dnd.modutime.core.room.integration;
 import static com.dnd.modutime.fixture.RoomRequestFixture.getRoomRequest;
 import static com.dnd.modutime.fixture.TimeFixture._12_00;
 import static com.dnd.modutime.fixture.TimeFixture._13_00;
+import static com.dnd.modutime.fixture.TimeFixture._2023_02_08;
+import static com.dnd.modutime.fixture.TimeFixture._2023_02_09;
 import static com.dnd.modutime.fixture.TimeFixture._2023_02_10;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -10,18 +12,19 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
 import com.dnd.modutime.config.TimeConfiguration;
-import com.dnd.modutime.core.room.application.request.RoomRequest;
-import com.dnd.modutime.core.timeblock.application.request.TimeReplaceRequest;
-import com.dnd.modutime.core.timetable.application.response.AvailableTimeInfo;
-import com.dnd.modutime.core.room.application.response.RoomCreationResponse;
-import com.dnd.modutime.core.timetable.application.response.TimeAndCountPerDate;
-import com.dnd.modutime.core.timetable.application.response.TimeTableResponse;
 import com.dnd.modutime.core.participant.application.ParticipantService;
 import com.dnd.modutime.core.room.application.RoomService;
+import com.dnd.modutime.core.room.application.request.RoomRequest;
+import com.dnd.modutime.core.room.application.response.RoomCreationResponse;
+import com.dnd.modutime.core.room.application.response.RoomInfoResponse;
 import com.dnd.modutime.core.timeblock.application.TimeBlockService;
 import com.dnd.modutime.core.timeblock.application.TimeReplaceValidator;
+import com.dnd.modutime.core.timeblock.application.request.TimeReplaceRequest;
 import com.dnd.modutime.core.timeblock.domain.TimeBlockReplaceEvent;
 import com.dnd.modutime.core.timetable.application.TimeTableService;
+import com.dnd.modutime.core.timetable.application.response.AvailableTimeInfo;
+import com.dnd.modutime.core.timetable.application.response.TimeAndCountPerDate;
+import com.dnd.modutime.core.timetable.application.response.TimeTableResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Disabled;
@@ -61,6 +64,20 @@ public class RoomIntegrationTest {
         RoomRequest roomRequest = getRoomRequest();
         RoomCreationResponse roomCreationResponse = roomService.create(roomRequest);
         assertThat(roomCreationResponse.getUuid()).isNotNull();
+    }
+
+    @Test
+    void 방정보_조회시_정렬된_날짜로_조회된다() {
+        // given
+        RoomRequest roomRequest = getRoomRequest(List.of(_2023_02_10, _2023_02_09, _2023_02_08));
+        RoomCreationResponse roomCreationResponse = roomService.create(roomRequest);
+
+        // when
+        RoomInfoResponse roomInfo = roomService.getInfo(roomCreationResponse.getUuid());
+
+        // then
+        assertThat(roomInfo.getDates())
+                .containsExactly(_2023_02_08, _2023_02_09, _2023_02_10);
     }
 
     // TODO: 위치 변경 필요


### PR DESCRIPTION
closed #60 


## 어떤 기능을 개발했나요?
- 방 정보 조회시 날짜가 정렬되어서 반환되도록 수정

## 어떻게 해결했나요?
- dto 생성시 조회조건 추가

## 어떤 부분에 집중하여 리뷰해야 할까요?


## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.