### PR TITLE
fix: deadline 이후에도 시간 교체를 가능하도록 변경한다

### DIFF
--- a/src/main/java/com/dnd/modutime/core/room/application/RoomTimeValidator.java
+++ b/src/main/java/com/dnd/modutime/core/room/application/RoomTimeValidator.java
@@ -1,19 +1,21 @@
 package com.dnd.modutime.core.room.application;
 
-import com.dnd.modutime.core.room.repository.RoomRepository;
-import com.dnd.modutime.core.timeblock.application.TimeReplaceValidator;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
 import com.dnd.modutime.core.room.domain.Room;
 import com.dnd.modutime.core.room.domain.RoomDate;
+import com.dnd.modutime.core.room.repository.RoomRepository;
+import com.dnd.modutime.core.timeblock.application.TimeReplaceValidator;
 import com.dnd.modutime.core.timeblock.domain.AvailableDateTime;
 import com.dnd.modutime.core.timeblock.domain.AvailableTime;
 import com.dnd.modutime.exception.NotFoundException;
 import com.dnd.modutime.util.TimeProvider;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -25,16 +27,8 @@ public class RoomTimeValidator implements TimeReplaceValidator {
     @Override
     public void validate(String roomUuid, List<AvailableDateTime> availableDateTimes) {
         Room room = getRoomByRoomUuid(roomUuid);
-        validateDeadLine(room.getDeadLineOrNull());
         validateContainsAllDates(room, availableDateTimes);
         validateStartAndEndTime(room, availableDateTimes);
-    }
-
-    private void validateDeadLine(LocalDateTime deadLineOrNull) {
-        LocalDateTime now = timeProvider.getCurrentLocalDateTime();
-        if (deadLineOrNull != null && now.isAfter(deadLineOrNull)) {
-            throw new IllegalArgumentException("데드라인 이후에는 방을 수정할 수 없습니다.");
-        }
     }
 
     private void validateContainsAllDates(Room room, List<AvailableDateTime> availableDateTimes) {

--- a/src/test/java/com/dnd/modutime/core/room/integration/RoomTimeValidatorTest.java
+++ b/src/test/java/com/dnd/modutime/core/room/integration/RoomTimeValidatorTest.java
@@ -10,6 +10,14 @@ import static com.dnd.modutime.fixture.TimeFixture._2023_02_20_00_00;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
 import com.dnd.modutime.config.TimeConfiguration;
 import com.dnd.modutime.core.room.application.RoomTimeValidator;
 import com.dnd.modutime.core.room.domain.Room;
@@ -18,12 +26,6 @@ import com.dnd.modutime.core.timeblock.domain.AvailableDateTime;
 import com.dnd.modutime.core.timeblock.domain.AvailableTime;
 import com.dnd.modutime.core.timeblock.domain.TimeBlock;
 import com.dnd.modutime.util.FakeTimeProvider;
-import java.util.List;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 
 @Import(TimeConfiguration.class)
 @SpringBootTest
@@ -80,14 +82,13 @@ class RoomTimeValidatorTest {
     }
 
     @Test
-    void 현재시간이_방의_데드라인이후인경우_예외가_발생한다() {
+    void 현재시간이_방의_데드라인이후인경우_예외가_발생하지_않는다() {
         Room room = getRoomByStartEndTime(_12_00, _13_00);
         Room savedRoom = roomRepository.save(room);
         List<AvailableDateTime> availableDateTimes = List.of(new AvailableDateTime(new TimeBlock(savedRoom.getUuid(),
                 "참여자1"), _2023_02_10, List.of(new AvailableTime(_12_00))));
         timeProvider.setTime(_2023_02_20_00_00);
-        assertThatThrownBy(() -> roomTimeValidator.validate(savedRoom.getUuid(), availableDateTimes))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertDoesNotThrow(() -> roomTimeValidator.validate(savedRoom.getUuid(), availableDateTimes));
     }
 
     @Test


### PR DESCRIPTION
closed
- #79 

## 어떤 기능을 개발했나요?
현재는 방의 deadline 이후이면 시간 교체가 불가능하게 validation이 설정되어있는데,
해당 validation을 제거함으로써 deadline 이후에도 시간 교체가 가능하도록 변경하였습니다.

## 어떻게 해결했나요?
해당 부분의 로직을 지우고, 기존 테스트 부분도 변경했습니다.

## 어떤 부분에 집중하여 리뷰해야 할까요?


## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.