### PR TITLE
fix: 연속되는 일정이 같은 후보시간으로 묶이지 않는 이슈 해결

### DIFF
--- a/src/main/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertor.java
+++ b/src/main/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertor.java
@@ -27,7 +27,7 @@ public class DateTimeRoomConvertor implements CandidateDateTimeConvertor {
             List<String> currentParticipantNames = currentDateTimeInfoDto.getParticipantNames();
             LocalDateTime currentStartDateTime = currentDateTimeInfoDto.getDateTime();
 
-            if (isContinuousTime(preStartDateTime, currentStartDateTime, preParticipantNames, currentParticipantNames)) {
+            if (isContinuousTime(preEndDateTime, currentStartDateTime, preParticipantNames, currentParticipantNames)) {
                 preEndDateTime = currentDateTimeInfoDto.getDateTime().plusMinutes(30);
                 continue;
             }
@@ -45,26 +45,22 @@ public class DateTimeRoomConvertor implements CandidateDateTimeConvertor {
         return candidateDateTimes;
     }
 
-    private boolean isContinuousTime(LocalDateTime preDateTime,
-                                     LocalDateTime currentLocalDateTime,
+    private boolean isContinuousTime(LocalDateTime preStartDateTime,
+                                     LocalDateTime currentStartDateTime,
                                      List<String> preParticipantNames,
                                      List<String> currentParticipantNames) {
-        if (isSameSize(preParticipantNames, currentParticipantNames)) {
-            return isContinuousTerm(preDateTime, currentLocalDateTime)
-                    && isSameNames(preParticipantNames, currentParticipantNames);
-        }
-        return false;
+
+        return isSameTime(preStartDateTime, currentStartDateTime) && isSameNames(preParticipantNames, currentParticipantNames);
     }
 
-    private boolean isSameSize(List<String> preParticipantNames, List<String> currentParticipantNames) {
-        return preParticipantNames.size() == currentParticipantNames.size();
-    }
-
-    private boolean isContinuousTerm(LocalDateTime preLocalDateTime, LocalDateTime currentLocalDateTime) {
-        return preLocalDateTime.plusMinutes(30).equals(currentLocalDateTime);
+    private boolean isSameTime(LocalDateTime preStartDateTime, LocalDateTime currentStartDateTime) {
+        return preStartDateTime.isEqual(currentStartDateTime);
     }
 
     private boolean isSameNames(List<String> preParticipantNames, List<String> currentParticipantNames) {
+        if (preParticipantNames.isEmpty()) {
+            return false;
+        }
         return currentParticipantNames.containsAll(preParticipantNames);
     }
 
@@ -72,6 +68,9 @@ public class DateTimeRoomConvertor implements CandidateDateTimeConvertor {
                                   LocalDateTime preStartDateTime,
                                   LocalDateTime preEndDateTime,
                                   List<String> preParticipantNames) {
+        if (preParticipantNames.isEmpty()) {
+            return;
+        }
         candidateDateTimes.add(new CandidateDateTime(null, preStartDateTime, preEndDateTime, null,
                 preParticipantNames.stream()
                         .map(CandidateDateTimeParticipantName::new)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertorTest.java
+++ b/src/test/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertorTest.java
@@ -31,7 +31,7 @@ public class DateTimeRoomConvertorTest {
         List<DateTimeInfoDto> dateTimeInfosDto = List.of(
                 new DateTimeInfoDto(LocalDateTime.of(_2023_02_09, _12_00), List.of("김동호", "이수진")),
                 new DateTimeInfoDto(LocalDateTime.of(_2023_02_09, _12_30), List.of("김동호", "이수진")),
-                new DateTimeInfoDto(LocalDateTime.of(_2023_02_09, _13_00), List.of("이세희")),
+                new DateTimeInfoDto(LocalDateTime.of(_2023_02_09, _13_00), List.of("김동호", "이수진")),
                 new DateTimeInfoDto(LocalDateTime.of(_2023_02_10, _12_30), List.of("이세희")),
                 new DateTimeInfoDto(LocalDateTime.of(_2023_02_10, _13_00), List.of("김동호", "이수진")),
                 new DateTimeInfoDto(LocalDateTime.of(_2023_02_10, _13_30), List.of("김동호", "이수진"))
@@ -41,34 +41,26 @@ public class DateTimeRoomConvertorTest {
         CandidateDateTime candidateDateTimeDto1 = candidateDateTimes.get(0);
         CandidateDateTime candidateDateTimeDto2 = candidateDateTimes.get(1);
         CandidateDateTime candidateDateTimeDto3 = candidateDateTimes.get(2);
-        CandidateDateTime candidateDateTimeDto4 = candidateDateTimes.get(3);
 
         assertAll(
                 () -> assertThat(candidateDateTimeDto1.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_09, _12_00)),
-                () -> assertThat(candidateDateTimeDto1.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_09, _13_00)),
+                () -> assertThat(candidateDateTimeDto1.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_09, _13_30)),
                 () -> assertThat(candidateDateTimeDto1.isConfirmed()).isNull(),
                 () -> assertThat(candidateDateTimeDto1.getParticipantNames().stream()
                         .map(CandidateDateTimeParticipantName::getName)
                         .collect(Collectors.toList())).hasSize(2)
                         .contains("김동호", "이수진"),
-                () -> assertThat(candidateDateTimeDto2.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_09, _13_00)),
-                () -> assertThat(candidateDateTimeDto2.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_09, _13_30)),
+                () -> assertThat(candidateDateTimeDto2.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _12_30)),
+                () -> assertThat(candidateDateTimeDto2.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _13_00)),
                 () -> assertThat(candidateDateTimeDto2.isConfirmed()).isNull(),
                 () -> assertThat(candidateDateTimeDto2.getParticipantNames().stream()
                         .map(CandidateDateTimeParticipantName::getName)
                         .collect(Collectors.toList())).hasSize(1)
                         .contains("이세희"),
-                () -> assertThat(candidateDateTimeDto3.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _12_30)),
-                () -> assertThat(candidateDateTimeDto3.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _13_00)),
+                () -> assertThat(candidateDateTimeDto3.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _13_00)),
+                () -> assertThat(candidateDateTimeDto3.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _14_00)),
                 () -> assertThat(candidateDateTimeDto3.isConfirmed()).isNull(),
                 () -> assertThat(candidateDateTimeDto3.getParticipantNames().stream()
-                        .map(CandidateDateTimeParticipantName::getName)
-                        .collect(Collectors.toList())).hasSize(1)
-                        .contains("이세희"),
-                () -> assertThat(candidateDateTimeDto4.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _13_00)),
-                () -> assertThat(candidateDateTimeDto4.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _14_00)),
-                () -> assertThat(candidateDateTimeDto4.isConfirmed()).isNull(),
-                () -> assertThat(candidateDateTimeDto4.getParticipantNames().stream()
                         .map(CandidateDateTimeParticipantName::getName)
                         .collect(Collectors.toList())).hasSize(2)
                         .contains("김동호", "이수진")


### PR DESCRIPTION
closed #81 


## 어떤 기능을 개발했나요?
- 연속되는 일정이 같은 후보시간으로 묶이지 않는 이슈를 해결했습니다.

## 어떻게 해결했나요?
- 연속된 시간을 판단하는 로직이 한시간 단위로만 묶을 수 있게 되어있었습니다.

### 기존 판단 로직
```java
    private boolean isContinuousTerm(LocalDateTime preLocalDateTime, LocalDateTime currentLocalDateTime) {
        return preLocalDateTime.plusMinutes(30).equals(currentLocalDateTime);
    }
```
pre의 start + 30 과 current의 start를 비교하고 있다.
이러면 2개 이상의 연속시간은 판단할 수 없다.

### 바뀐 판단 로직
```java
    private boolean isContinuousTime(LocalDateTime preStartDateTime,
                                     LocalDateTime currentStartDateTime,
                                     List<String> preParticipantNames,
                                     List<String> currentParticipantNames) {

        return isSameTime(preStartDateTime, currentStartDateTime) && isSameNames(preParticipantNames, currentParticipantNames);
    }
```
pre의 end와 current의 start를 비교한다.
그러면 몇개가 이어지는 하나로 묶을 수 있게 된다.

## 어떤 부분에 집중하여 리뷰해야 할까요?
- 사이드 이펙트가 없는지 확인해주세요.

## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과
<img width="380" alt="스크린샷 2023-07-03 16 24 23" src="https://github.com/dnd-side-project/dnd-8th-5-backend/assets/54317630/084cceef-def3-4322-999c-cc97243d0cda">



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.