### PR TITLE
fix: 되는 시간이 없을때 후보시간 조회시 500 에러를 해결한다

### DIFF
--- a/src/main/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertor.java
+++ b/src/main/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertor.java
@@ -15,6 +15,9 @@ public class DateTimeRoomConvertor implements CandidateDateTimeConvertor {
     @Override
     public List<CandidateDateTime> convert(List<DateTimeInfoDto> dateTimeInfosDto) {
         List<CandidateDateTime> candidateDateTimes = new ArrayList<>();
+        if (dateTimeInfosDto.isEmpty()) {
+            return candidateDateTimes;
+        }
         DateTimeInfoDto firstDateTimeInfoDto = dateTimeInfosDto.get(0);
 
         LocalDateTime preStartDateTime = firstDateTimeInfoDto.getDateTime();

--- a/src/test/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertorTest.java
+++ b/src/test/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertorTest.java
@@ -66,4 +66,11 @@ public class DateTimeRoomConvertorTest {
                         .contains("김동호", "이수진")
         );
     }
+
+    @Test
+    void dateInfosDto이_비어있을경우_빈리스트를_반환한다() {
+        List<DateTimeInfoDto> dateTimeInfosDto = List.of();
+        List<CandidateDateTime> candidateDateTimes = dateTimeRoomConvertor.convert(dateTimeInfosDto);
+        assertThat(candidateDateTimes).isEmpty();
+    }
 }


### PR DESCRIPTION
closed #84 


## 어떤 기능을 개발했나요?
- 되는 시간이 없을때 후보시간 조회시 500 에러 해결

## 어떻게 해결했나요?
- empty를 검증해 비어있을 경우 빈 리스트를 반환하도록 했습니다.

## 어떤 부분에 집중하여 리뷰해야 할까요?
- 코드가 약간 하드코딩 같은데, 여기 추후에 DFS로 변환하는거 설계해서 공유해보겠습니다~!


## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.