### PR TITLE
fix: 날짜만 있는 방의 시간이 교체되지 않는 문제를 해결한다

### DIFF
--- a/src/main/java/com/dnd/modutime/core/timetable/domain/DateInfo.java
+++ b/src/main/java/com/dnd/modutime/core/timetable/domain/DateInfo.java
@@ -78,7 +78,7 @@ public class DateInfo {
             return;
         }
         List<AvailableTime> timesOrNull = availableDateTime.getTimesOrNull();
-        if (timesOrNull == null) {
+        if (timesOrNull == null || timesOrNull.isEmpty()) {
             validateTimeInfoIsEmpty();
             TimeInfo timeInfo = timeInfos.get(0);
             timeInfo.removeParticipantName(participantName);

--- a/src/main/java/com/dnd/modutime/core/timetable/domain/DateInfo.java
+++ b/src/main/java/com/dnd/modutime/core/timetable/domain/DateInfo.java
@@ -59,8 +59,7 @@ public class DateInfo {
         if (!this.date.isEqual(date)) {
             return List.of();
         }
-        if (timesOrNull == null) {
-            validateTimeInfoIsEmpty();
+        if (timesOrNull == null || timesOrNull.isEmpty()) {
             return List.of(timeInfos.get(0).getId());
         }
         List<Long> timeInfoIds = new ArrayList<>();

--- a/src/test/java/com/dnd/modutime/acceptance/AcceptanceSupporter.java
+++ b/src/test/java/com/dnd/modutime/acceptance/AcceptanceSupporter.java
@@ -1,6 +1,7 @@
 package com.dnd.modutime.acceptance;
 
 import static com.dnd.modutime.fixture.RoomRequestFixture.getRoomRequest;
+import static com.dnd.modutime.fixture.TimeFixture._00_00;
 import static com.dnd.modutime.fixture.TimeFixture._11_00;
 import static com.dnd.modutime.fixture.TimeFixture._11_30;
 import static com.dnd.modutime.fixture.TimeFixture._12_00;
@@ -13,15 +14,14 @@ import static com.dnd.modutime.fixture.TimeFixture._2023_02_10;
 
 import com.dnd.modutime.config.TimeConfiguration;
 import com.dnd.modutime.core.auth.application.request.LoginRequest;
-import com.dnd.modutime.core.room.application.request.RoomRequest;
-import com.dnd.modutime.core.timeblock.application.request.TimeReplaceRequest;
 import com.dnd.modutime.core.participant.application.response.EmailResponse;
+import com.dnd.modutime.core.room.application.request.RoomRequest;
 import com.dnd.modutime.core.room.application.response.RoomCreationResponse;
+import com.dnd.modutime.core.timeblock.application.request.TimeReplaceRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -108,14 +108,14 @@ public class AcceptanceSupporter {
         로그인후_시간을_등록한다(roomUuid,
                 "김동호",
                 false,
-                List.of(LocalDateTime.of(_2023_02_08, LocalTime.of(0, 0)),
-                        LocalDateTime.of(_2023_02_10, LocalTime.of(0, 0))
+                List.of(LocalDateTime.of(_2023_02_08, _00_00),
+                        LocalDateTime.of(_2023_02_10, _00_00)
                 )
         );
         로그인후_시간을_등록한다(roomUuid,
                 "이수진",
                 false,
-                List.of(LocalDateTime.of(_2023_02_10, LocalTime.of(0, 0)))
+                List.of(LocalDateTime.of(_2023_02_10, _00_00))
         );
     }
 

--- a/src/test/java/com/dnd/modutime/acceptance/TimeBlockAcceptanceTest.java
+++ b/src/test/java/com/dnd/modutime/acceptance/TimeBlockAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.dnd.modutime.acceptance;
 
 import static com.dnd.modutime.fixture.RoomRequestFixture.getRoomRequestNoTime;
+import static com.dnd.modutime.fixture.TimeFixture._00_00;
 import static com.dnd.modutime.fixture.TimeFixture._12_00;
 import static com.dnd.modutime.fixture.TimeFixture._13_00;
 import static com.dnd.modutime.fixture.TimeFixture._2023_02_10;
@@ -36,7 +37,7 @@ public class TimeBlockAcceptanceTest extends AcceptanceSupporter {
         String participantName = "참여자1";
         로그인_참여자_1234(roomCreationResponse.getUuid(), participantName);
         ExtractableResponse<Response> response = 시간을_등록한다(roomCreationResponse.getUuid(), participantName, false,
-                List.of(LocalDateTime.of(_2023_02_10, LocalTime.of(0, 0))));
+                List.of(LocalDateTime.of(_2023_02_10, _00_00)));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }

--- a/src/test/java/com/dnd/modutime/acceptance/TimeTableAcceptanceTest.java
+++ b/src/test/java/com/dnd/modutime/acceptance/TimeTableAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.dnd.modutime.acceptance;
 
 import static com.dnd.modutime.fixture.RoomRequestFixture.getRoomRequest;
 import static com.dnd.modutime.fixture.RoomRequestFixture.getRoomRequestNoTime;
+import static com.dnd.modutime.fixture.TimeFixture._00_00;
 import static com.dnd.modutime.fixture.TimeFixture._11_00;
 import static com.dnd.modutime.fixture.TimeFixture._11_30;
 import static com.dnd.modutime.fixture.TimeFixture._12_00;
@@ -20,6 +21,7 @@ import com.dnd.modutime.core.timetable.application.response.TimeAndCountPerDate;
 import com.dnd.modutime.core.timetable.application.response.TimeTableResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -92,6 +94,92 @@ public class TimeTableAcceptanceTest extends AcceptanceSupporter {
                 () -> assertThat(_02_10.getAvailableDate()).isEqualTo(_2023_02_10),
                 () -> assertThat(_02_10.getAvailableTimeInfos()).contains(
                         new AvailableTimeInfo(null, 2)
+                )
+        );
+    }
+
+    @Test
+    void 시간이_있는_방의_참여자가_시간을_수정하면_TimeTable에도_반영되어야_한다() {
+        RoomCreationResponse roomCreationResponse = 방_생성(getRoomRequest(List.of(_2023_02_08, _2023_02_09, _2023_02_10)));
+        String roomUuid = roomCreationResponse.getUuid();
+        세명의_날짜와_시간을_등록한다(roomUuid);
+        // 2023.02.10 13:00 의 시간만 제거
+        시간을_등록한다(roomUuid, "김동호", true, List.of(LocalDateTime.of(_2023_02_08, _11_00),
+                LocalDateTime.of(_2023_02_08, _11_30),
+                LocalDateTime.of(_2023_02_08, _13_00),
+
+                LocalDateTime.of(_2023_02_09, _11_00),
+                LocalDateTime.of(_2023_02_09, _11_30),
+                LocalDateTime.of(_2023_02_09, _13_00),
+
+                LocalDateTime.of(_2023_02_10, _11_00),
+                LocalDateTime.of(_2023_02_10, _11_30)
+        ));
+
+        ExtractableResponse<Response> response = get("/api/room/" + roomUuid + "/available-time/group");
+        TimeTableResponse timeTableResponse = response.body().as(TimeTableResponse.class);
+        List<TimeAndCountPerDate> timeAndCountPerDates = timeTableResponse.getTimeAndCountPerDates();
+        TimeAndCountPerDate _02_08 = timeAndCountPerDates.get(0);
+        TimeAndCountPerDate _02_09 = timeAndCountPerDates.get(1);
+        TimeAndCountPerDate _02_10 = timeAndCountPerDates.get(2);
+        assertAll(
+                () -> assertThat(_02_08.getAvailableDate()).isEqualTo(_2023_02_08),
+                () -> assertThat(_02_08.getAvailableTimeInfos()).contains(
+                        new AvailableTimeInfo(_11_00, 3),
+                        new AvailableTimeInfo(_11_30, 3),
+                        new AvailableTimeInfo(_12_00, 1),
+                        new AvailableTimeInfo(_12_30, 1),
+                        new AvailableTimeInfo(_13_00, 2),
+                        new AvailableTimeInfo(_13_30, 0)
+                ),
+                () -> assertThat(_02_09.getAvailableDate()).isEqualTo(_2023_02_09),
+                () -> assertThat(_02_09.getAvailableTimeInfos()).contains(
+                        new AvailableTimeInfo(_11_00, 1),
+                        new AvailableTimeInfo(_11_30, 1),
+                        new AvailableTimeInfo(_12_00, 1),
+                        new AvailableTimeInfo(_12_30, 0),
+                        new AvailableTimeInfo(_13_00, 3),
+                        new AvailableTimeInfo(_13_30, 1)
+                ),
+                () -> assertThat(_02_10.getAvailableDate()).isEqualTo(_2023_02_10),
+                () -> assertThat(_02_10.getAvailableTimeInfos()).contains(
+                        new AvailableTimeInfo(_11_00, 1),
+                        new AvailableTimeInfo(_11_30, 3),
+                        new AvailableTimeInfo(_12_00, 1),
+                        new AvailableTimeInfo(_12_30, 2),
+                        new AvailableTimeInfo(_13_00, 0),
+                        new AvailableTimeInfo(_13_30, 2)
+                )
+        );
+    }
+
+    @Test
+    void 시간이_없는_방의_참여자가_시간을_수정하면_TimeTable에도_반영되어야_한다() {
+        RoomCreationResponse roomCreationResponse = 방_생성(getRoomRequestNoTime(List.of(_2023_02_08, _2023_02_09, _2023_02_10)));
+        String roomUuid = roomCreationResponse.getUuid();
+        두명의_날짜를_등록한다(roomUuid);
+        시간을_등록한다(roomUuid, "김동호", false,
+                List.of(LocalDateTime.of(_2023_02_09, _00_00))
+        );
+
+        ExtractableResponse<Response> response = get("/api/room/" + roomUuid + "/available-time/group");
+        TimeTableResponse timeTableResponse = response.body().as(TimeTableResponse.class);
+        List<TimeAndCountPerDate> timeAndCountPerDates = timeTableResponse.getTimeAndCountPerDates();
+        TimeAndCountPerDate _02_08 = timeAndCountPerDates.get(0);
+        TimeAndCountPerDate _02_09 = timeAndCountPerDates.get(1);
+        TimeAndCountPerDate _02_10 = timeAndCountPerDates.get(2);
+        assertAll(
+                () -> assertThat(_02_08.getAvailableDate()).isEqualTo(_2023_02_08),
+                () -> assertThat(_02_08.getAvailableTimeInfos()).contains(
+                        new AvailableTimeInfo(null, 0)
+                ),
+                () -> assertThat(_02_09.getAvailableDate()).isEqualTo(_2023_02_09),
+                () -> assertThat(_02_09.getAvailableTimeInfos()).contains(
+                        new AvailableTimeInfo(null, 1)
+                ),
+                () -> assertThat(_02_10.getAvailableDate()).isEqualTo(_2023_02_10),
+                () -> assertThat(_02_10.getAvailableTimeInfos()).contains(
+                        new AvailableTimeInfo(null, 1)
                 )
         );
     }

--- a/src/test/java/com/dnd/modutime/core/timeblock/integration/TimeBlockIntegrationTest.java
+++ b/src/test/java/com/dnd/modutime/core/timeblock/integration/TimeBlockIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.dnd.modutime.core.timeblock.integration;
 
 import static com.dnd.modutime.fixture.RoomRequestFixture.ROOM_UUID;
+import static com.dnd.modutime.fixture.TimeFixture._00_00;
 import static com.dnd.modutime.fixture.TimeFixture._12_00;
 import static com.dnd.modutime.fixture.TimeFixture._13_00;
 import static com.dnd.modutime.fixture.TimeFixture._2023_02_09;
@@ -23,7 +24,6 @@ import com.dnd.modutime.core.timeblock.domain.TimeBlock;
 import com.dnd.modutime.core.timeblock.repository.AvailableDateTimeRepository;
 import com.dnd.modutime.core.timeblock.repository.TimeBlockRepository;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -79,7 +79,7 @@ class TimeBlockIntegrationTest {
         TimeBlock savedTimeBlock = timeBlockRepository.save(new TimeBlock(ROOM_UUID, "참여자1"));
 
         // when
-        TimeReplaceRequest timeReplaceRequest = new TimeReplaceRequest("참여자1", false, List.of(LocalDateTime.of(_2023_02_10, LocalTime.of(0, 0))));
+        TimeReplaceRequest timeReplaceRequest = new TimeReplaceRequest("참여자1", false, List.of(LocalDateTime.of(_2023_02_10, _00_00)));
         timeBlockService.replace(ROOM_UUID, timeReplaceRequest);
 
         // then


### PR DESCRIPTION
closed #86 


## 어떤 기능을 개발했나요?
- 날짜만 있는 방의 시간이 교체되지 않는 문제를 해결

1. delete 시에 엔티티의 관계를 먼저 제거하고 delete를 실행해야합니다.
2. AvailableDateTime List가 null인 경우에 JPA가 null이 아닌 빈 리스트로 가져옵니다.
3. 그래서 엔티티를 삭제해주는 로직을 타지못한 에러였습니다.


## 어떻게 해결했나요?

- 빈 리스트를 가져올때 엔티티를 삭제해주도록 수정하였습니다.


## 어떤 부분에 집중하여 리뷰해야 할까요?


## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.