### PR TITLE
refactor: 빠른순 정렬시 오래걸리는순 조건 제거

### DIFF
--- a/src/main/java/com/dnd/modutime/core/adjustresult/util/sorter/FastFirstSorter.java
+++ b/src/main/java/com/dnd/modutime/core/adjustresult/util/sorter/FastFirstSorter.java
@@ -5,7 +5,6 @@ import java.util.Comparator;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
-// TODO: test
 @Component
 public class FastFirstSorter implements CandidateDateTimesSorter{
 
@@ -13,8 +12,7 @@ public class FastFirstSorter implements CandidateDateTimesSorter{
     public void sort(List<CandidateDateTime> candidateDateTimes) {
         Comparator<CandidateDateTime> compare = Comparator
                 .comparing(CandidateDateTime::getParticipantSize, Comparator.reverseOrder())
-                .thenComparing(CandidateDateTime::getStartDateTime)
-                .thenComparing(CandidateDateTime::calculateTerm);
+                .thenComparing(CandidateDateTime::getStartDateTime);
         candidateDateTimes.sort(compare);
     }
 }

--- a/src/test/java/com/dnd/modutime/core/adjustresult/util/sorter/FastFirstSorterTest.java
+++ b/src/test/java/com/dnd/modutime/core/adjustresult/util/sorter/FastFirstSorterTest.java
@@ -1,0 +1,42 @@
+package com.dnd.modutime.core.adjustresult.util.sorter;
+
+import static com.dnd.modutime.fixture.TimeFixture._11_00;
+import static com.dnd.modutime.fixture.TimeFixture._12_00;
+import static com.dnd.modutime.fixture.TimeFixture._14_00;
+import static com.dnd.modutime.fixture.TimeFixture._2023_02_08;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dnd.modutime.core.adjustresult.domain.CandidateDateTime;
+import com.dnd.modutime.core.adjustresult.domain.CandidateDateTimeParticipantName;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class FastFirstSorterTest {
+
+    private final CandidateDateTimesSorter candidateDateTimesSorter = new FastFirstSorter();
+
+    @Test
+    void 인원이_가장_많고_빠른시간_순으로_정렬된다() {
+        List<CandidateDateTime> candidateDateTimes = new ArrayList<>();
+        candidateDateTimes.add(getCandidateTime(LocalDateTime.of(_2023_02_08, _12_00), LocalDateTime.of(_2023_02_08, _14_00), List.of("수진", "동호", "주현")));
+        candidateDateTimes.add(getCandidateTime(LocalDateTime.of(_2023_02_08, _11_00), LocalDateTime.of(_2023_02_08, _14_00), List.of("수진", "동호", "세희")));
+        candidateDateTimes.add(getCandidateTime(LocalDateTime.of(_2023_02_08, _14_00), LocalDateTime.of(_2023_02_08, _14_00), List.of("수진")));
+        candidateDateTimesSorter.sort(candidateDateTimes);
+        assertThat(candidateDateTimes.stream()
+                .map(CandidateDateTime::getStartDateTime)
+                .collect(Collectors.toList()))
+                .containsExactly(LocalDateTime.of(_2023_02_08, _11_00),
+                        LocalDateTime.of(_2023_02_08, _12_00),
+                        LocalDateTime.of(_2023_02_08, _14_00));
+    }
+
+    private CandidateDateTime getCandidateTime(LocalDateTime startTime, LocalDateTime endTime, List<String> names) {
+        return new CandidateDateTime(null, startTime, endTime, false,
+                names.stream()
+                        .map(CandidateDateTimeParticipantName::new)
+                        .collect(Collectors.toList()));
+    }
+}


### PR DESCRIPTION
closed #89 


## 어떤 기능을 개발했나요?
- 빠른순 정렬시 오래걸리는순 조건 제거


## 어떻게 해결했나요?
- 조건을 제거하고 테스트를 추가하였습니다.

## 어떤 부분에 집중하여 리뷰해야 할까요?


## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.