### PR TITLE
fix: timeBlock으로 묶을때 인원이 정확히 일치해야 같은 block으로 판단하도록 수정

### DIFF
--- a/src/main/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertor.java
+++ b/src/main/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertor.java
@@ -64,12 +64,14 @@ public class DateTimeRoomConvertor implements CandidateDateTimeConvertor {
         if (preParticipantNames.isEmpty()) {
             return false;
         }
-        return containsExactly(preParticipantNames, currentParticipantNames);
+        return haveSameElements(preParticipantNames, currentParticipantNames);
     }
 
-    private boolean containsExactly(List<String> preParticipantNames, List<String> currentParticipantNames) {
-        return currentParticipantNames.containsAll(preParticipantNames)
-                && currentParticipantNames.size() == preParticipantNames.size();
+    private boolean haveSameElements(List<String> preParticipantNames, List<String> currentParticipantNames) {
+        if (currentParticipantNames.size() != preParticipantNames.size()) {
+            return false;
+        }
+        return currentParticipantNames.containsAll(preParticipantNames);
     }
 
     private void addCandidateTime(List<CandidateDateTime> candidateDateTimes,

--- a/src/main/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertor.java
+++ b/src/main/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertor.java
@@ -64,7 +64,12 @@ public class DateTimeRoomConvertor implements CandidateDateTimeConvertor {
         if (preParticipantNames.isEmpty()) {
             return false;
         }
-        return currentParticipantNames.containsAll(preParticipantNames);
+        return containsExactly(preParticipantNames, currentParticipantNames);
+    }
+
+    private boolean containsExactly(List<String> preParticipantNames, List<String> currentParticipantNames) {
+        return currentParticipantNames.containsAll(preParticipantNames)
+                && currentParticipantNames.size() == preParticipantNames.size();
     }
 
     private void addCandidateTime(List<CandidateDateTime> candidateDateTimes,

--- a/src/test/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertorTest.java
+++ b/src/test/java/com/dnd/modutime/core/adjustresult/util/convertor/DateTimeRoomConvertorTest.java
@@ -29,7 +29,7 @@ public class DateTimeRoomConvertorTest {
     @Test
     void dateInfosDto를_candidateDateTime으로_변환한다() {
         List<DateTimeInfoDto> dateTimeInfosDto = List.of(
-                new DateTimeInfoDto(LocalDateTime.of(_2023_02_09, _12_00), List.of("김동호", "이수진")),
+                new DateTimeInfoDto(LocalDateTime.of(_2023_02_09, _12_00), List.of("김동호")),
                 new DateTimeInfoDto(LocalDateTime.of(_2023_02_09, _12_30), List.of("김동호", "이수진")),
                 new DateTimeInfoDto(LocalDateTime.of(_2023_02_09, _13_00), List.of("김동호", "이수진")),
                 new DateTimeInfoDto(LocalDateTime.of(_2023_02_10, _12_30), List.of("이세희")),
@@ -41,26 +41,34 @@ public class DateTimeRoomConvertorTest {
         CandidateDateTime candidateDateTimeDto1 = candidateDateTimes.get(0);
         CandidateDateTime candidateDateTimeDto2 = candidateDateTimes.get(1);
         CandidateDateTime candidateDateTimeDto3 = candidateDateTimes.get(2);
+        CandidateDateTime candidateDateTimeDto4 = candidateDateTimes.get(3);
 
         assertAll(
                 () -> assertThat(candidateDateTimeDto1.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_09, _12_00)),
-                () -> assertThat(candidateDateTimeDto1.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_09, _13_30)),
+                () -> assertThat(candidateDateTimeDto1.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_09, _12_30)),
                 () -> assertThat(candidateDateTimeDto1.isConfirmed()).isNull(),
                 () -> assertThat(candidateDateTimeDto1.getParticipantNames().stream()
                         .map(CandidateDateTimeParticipantName::getName)
-                        .collect(Collectors.toList())).hasSize(2)
-                        .contains("김동호", "이수진"),
-                () -> assertThat(candidateDateTimeDto2.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _12_30)),
-                () -> assertThat(candidateDateTimeDto2.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _13_00)),
+                        .collect(Collectors.toList())).hasSize(1)
+                        .contains("김동호"),
+                () -> assertThat(candidateDateTimeDto2.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_09, _12_30)),
+                () -> assertThat(candidateDateTimeDto2.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_09, _13_30)),
                 () -> assertThat(candidateDateTimeDto2.isConfirmed()).isNull(),
                 () -> assertThat(candidateDateTimeDto2.getParticipantNames().stream()
                         .map(CandidateDateTimeParticipantName::getName)
-                        .collect(Collectors.toList())).hasSize(1)
-                        .contains("이세희"),
-                () -> assertThat(candidateDateTimeDto3.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _13_00)),
-                () -> assertThat(candidateDateTimeDto3.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _14_00)),
+                        .collect(Collectors.toList())).hasSize(2)
+                        .contains("김동호", "이수진"),
+                () -> assertThat(candidateDateTimeDto3.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _12_30)),
+                () -> assertThat(candidateDateTimeDto3.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _13_00)),
                 () -> assertThat(candidateDateTimeDto3.isConfirmed()).isNull(),
                 () -> assertThat(candidateDateTimeDto3.getParticipantNames().stream()
+                        .map(CandidateDateTimeParticipantName::getName)
+                        .collect(Collectors.toList())).hasSize(1)
+                        .contains("이세희"),
+                () -> assertThat(candidateDateTimeDto4.getStartDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _13_00)),
+                () -> assertThat(candidateDateTimeDto4.getEndDateTime()).isEqualTo(LocalDateTime.of(_2023_02_10, _14_00)),
+                () -> assertThat(candidateDateTimeDto4.isConfirmed()).isNull(),
+                () -> assertThat(candidateDateTimeDto4.getParticipantNames().stream()
                         .map(CandidateDateTimeParticipantName::getName)
                         .collect(Collectors.toList())).hasSize(2)
                         .contains("김동호", "이수진")


### PR DESCRIPTION
closed #96 


## 어떤 기능을 개발했나요?
- 우선순위 계산이 제대로 되지 않던 문제를 해결했습니다.

## 어떻게 해결했나요?
- timeBlock으로 묶을때 인원이 정확히 일치해야 같은 block으로 판단하도록 수정하였습니다.
- 같은 후보시간으로 묶을 때 containsAll()로 판단하다보니 "동호" 하나만 존재해도 "동호", "수진" 후보시간과 같이 묶이고 있었습니다.
   - size까지 같이 비교해 정확히 인원이 일치해야 같은 후보시간(block)으로 판단하도록 수정하였습니다.
- 테스트케이스에서 위의 케이스를 검증하지 않고있어서 테스트케이스도 약간 수정하였습니다.

## 어떤 부분에 집중하여 리뷰해야 할까요?
- 정확히 일치하게 인원을 묶을시 어떤 사이드 이펙트가 있을지 판단해주세요.

## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.