### PR TITLE
feat: 새로운 인스턴스를 연결한다

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -74,9 +74,11 @@ jobs:
           key: ${{ secrets.KEY }}
           script: |
             cd /home/ubuntu/srv/ubuntu
+            cat > .env << EOL
             DB_URL=${{secrets.PROD_DB_URL}}
             DB_USERNAME=${{secrets.PROD_DB_USERNAME}}
             DB_PASSWORD=${{secrets.PROD_DB_PASSWORD}}
+            EOL
             sudo sh install-docker.sh
             sudo docker rm -f $(docker ps -qa)
             sudo docker pull ${{ secrets.DOCKER_REPO }}/modutime-web

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -84,5 +84,5 @@ jobs:
             sudo docker rm -f $(docker ps -qa)
             sudo docker pull ${{ secrets.DOCKER_REPO }}/modutime-web
             sudo docker pull ${{ secrets.DOCKER_REPO }}/modutime-nginx
-            sudo docker-compose --env-file /home/ubuntu/.env up -d
+            sudo docker-compose --env-file /home/ubuntu/srv/ubuntu/.env up -d
             sudo docker image prune -f

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -40,7 +40,7 @@ jobs:
       - name: create remote directory
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.HOST }}
+          host: ${{ secrets.HOST_2 }}
           username: ubuntu
           key: ${{ secrets.KEY }}
           script: mkdir -p /home/ubuntu/srv/ubuntu
@@ -50,7 +50,7 @@ jobs:
         with:
           switches: -avzr --delete
           remote_path: /home/ubuntu/srv/ubuntu
-          remote_host: ${{ secrets.HOST }}
+          remote_host: ${{ secrets.HOST_2 }}
           remote_user: ubuntu
           remote_key: ${{ secrets.KEY }}
 
@@ -69,7 +69,7 @@ jobs:
       - name: executing remote ssh commands using password
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.HOST }}
+          host: ${{ secrets.HOST_2 }}
           username: ubuntu
           key: ${{ secrets.KEY }}
           script: |

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -79,9 +79,10 @@ jobs:
             DB_USERNAME=${{secrets.PROD_DB_USERNAME}}
             DB_PASSWORD=${{secrets.PROD_DB_PASSWORD}}
             EOL
+            
             sudo sh install-docker.sh
             sudo docker rm -f $(docker ps -qa)
             sudo docker pull ${{ secrets.DOCKER_REPO }}/modutime-web
             sudo docker pull ${{ secrets.DOCKER_REPO }}/modutime-nginx
-            sudo docker-compose up -d
+            sudo docker-compose --env-file /home/ubuntu/.env up -d
             sudo docker image prune -f

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -84,5 +84,6 @@ jobs:
             sudo docker rm -f $(docker ps -qa)
             sudo docker pull ${{ secrets.DOCKER_REPO }}/modutime-web
             sudo docker pull ${{ secrets.DOCKER_REPO }}/modutime-nginx
-            sudo docker-compose --env-file /home/ubuntu/srv/ubuntu/.env up -d
+
+            sudo docker-compose --env-file .env up -d
             sudo docker image prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,11 @@ services:
       - "8080"
     ports:
       - "8080:8080"
-
+    environment:
+      DB_URL: ${DB_URL}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+  
   nginx:
     container_name: nginx
     image: ssssujini99/modutime-nginx

--- a/src/main/resources/application-db.yaml
+++ b/src/main/resources/application-db.yaml
@@ -22,14 +22,14 @@ spring:
     activate:
       on-profile: prod
   jpa:
-    show-sql: true
+    show-sql: false
     generate-ddl: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
   datasource:
-    url: { DB_URL }
-    username: { DB_USERNAME }
-    password: { DB_PASSWORD }
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
   sql:
     init:


### PR DESCRIPTION
closed 

# 문제 상황
- 예전에 생성한 방 접근이 되지 않는다.
- 2주전에 배포한 서버가 h2 local DB 로 실행되었기 때문이다. 2주간 방치됨.
- 인메모리 DB이고, console 설정도 켜놓지 않아 해당 DB의 데이터 백업이 불가능하다.
   - jdbc:h2:mem:testdb 로 접근 시도해도 새로운 데이터베이스 인스턴스로 생성되어 실제 JVM의 인메모리 DB에 접근이 안됨.
- sql 로그를 추출해보았는데, 3기가 넘고 제대로 추출되지 않는다.

## 어떤 기능을 개발했나요?
- 실제 DB에 연결시킨 새로운 인스턴스를 띄우고 배포한다.
- ddl update 를 제거한다.
- docker compose 에서 환경변수를 읽도록 수정한다.

## 어떻게 해결했나요?
- 클라이언트측에서 새로운 API 주소로 요청하고 / 404 에러가 뜬다면 기존 API로 요청하도록 한다.
- 지난 2주간의 DB 복구는 불가능하지만, 사용자에게는 장애 없이 접근이 가능하다.

## 어떤 부분에 집중하여 리뷰해야 할까요?


## (option) 이 부분은 주의해 주세요.


## (option) 참고자료


## (option) 결과



---

## RCA rule
- r: 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- c: 웬만하면 반영해 주세요.
- a: 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- 규칙
    - submit 할 코멘트들 중에서 1개라도 r이 포함되어 있다면 request change를 날린다.
    - r 이 하나도 없다면 approve를 한다.