### PR TITLE
feat: 배포 워크플로우에 SSH 타겟 그룹 등록/해제 추가

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -180,6 +180,10 @@ jobs:
             --target-group-arn ${{ secrets.TARGET_GROUP_ARN }} \
             --targets Id=${{ steps.green.outputs.instance_id }}
 
+          aws elbv2 register-targets \
+            --target-group-arn ${{ secrets.SSH_TARGET_GROUP_ARN }} \
+            --targets Id=${{ steps.green.outputs.instance_id }}
+
           echo "타겟 그룹 healthy 대기 중..."
           aws elbv2 wait target-in-service \
             --target-group-arn ${{ secrets.TARGET_GROUP_ARN }} \
@@ -193,6 +197,9 @@ jobs:
             echo "Blue 제거: $INSTANCE_ID"
             aws elbv2 deregister-targets \
               --target-group-arn ${{ secrets.TARGET_GROUP_ARN }} \
+              --targets Id=$INSTANCE_ID
+            aws elbv2 deregister-targets \
+              --target-group-arn ${{ secrets.SSH_TARGET_GROUP_ARN }} \
               --targets Id=$INSTANCE_ID
           done
 
@@ -218,6 +225,9 @@ jobs:
             echo "배포 실패 - Green 인스턴스 정리: ${{ steps.green.outputs.instance_id }}"
             aws elbv2 deregister-targets \
               --target-group-arn ${{ secrets.TARGET_GROUP_ARN }} \
+              --targets Id=${{ steps.green.outputs.instance_id }} 2>/dev/null || true
+            aws elbv2 deregister-targets \
+              --target-group-arn ${{ secrets.SSH_TARGET_GROUP_ARN }} \
               --targets Id=${{ steps.green.outputs.instance_id }} 2>/dev/null || true
             aws ec2 terminate-instances \
               --instance-ids ${{ steps.green.outputs.instance_id }} 2>/dev/null || true


### PR DESCRIPTION
## Summary
- NLB에 SSH(22번 포트) 리스너를 추가하여 고정 도메인으로 DB SSH 터널링 접속 가능하도록 설정
- 블루-그린 배포 시 SSH 타겟 그룹(`prod-modutime-ssh`)도 함께 관리되도록 워크플로우 수정
  - Green 등록, Blue 해제, 롤백 정리 3곳에 `SSH_TARGET_GROUP_ARN` 처리 추가

## 사전 작업
- [x] NLB에 TCP:22 리스너 생성 완료
- [x] `prod-modutime-ssh` 타겟 그룹 생성 완료
- [x] GitHub Secrets에 `SSH_TARGET_GROUP_ARN` 추가 필요

## Test plan
- [ ] GitHub Secrets에 `SSH_TARGET_GROUP_ARN` 등록
- [ ] 배포 실행 후 SSH 타겟 그룹에 새 인스턴스가 healthy인지 확인
- [ ] NLB DNS로 SSH 접속 확인 (DataGrip/Termius)

🤖 Generated with [Claude Code](https://claude.com/claude-code)