### PR TITLE
ci: main 머지 시 release 태그 자동 생성

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,38 @@
+name: Create Release Tag
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Create release tag
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          PREFIX="release-${TODAY}"
+
+          LAST_BUILD=$(git tag -l "${PREFIX}-*" | sed "s/${PREFIX}-//" | sort -n | tail -1)
+
+          if [ -z "$LAST_BUILD" ]; then
+            BUILD_NUMBER=1
+          else
+            BUILD_NUMBER=$((LAST_BUILD + 1))
+          fi
+
+          TAG_NAME="${PREFIX}-${BUILD_NUMBER}"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
+          echo "### :label: Created tag: \`${TAG_NAME}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/src/main/java/com/dnd/modutime/core/auth/oauth/facade/OAuth2TokenProvider.java
+++ b/src/main/java/com/dnd/modutime/core/auth/oauth/facade/OAuth2TokenProvider.java
@@ -168,16 +168,8 @@ public class OAuth2TokenProvider {
         User user = userRepository.findByEmailAndProvider(email, provider)
                 .orElseThrow();
 
-        OAuth2User principal = new OAuth2User(
-                new User(user.getName(),
-                        email,
-                        user.getProfileImage(),
-                        user.getThumbnailImage(),
-                        provider
-                ),
-                claims,
-                "sub"
-        );
+        OAuth2User principal = new OAuth2User(user, claims, "sub");
+        this.userCache.putUserInCache(principal);
 
         return new OAuth2AuthenticationToken(principal, Collections.emptyList(), registrationId);
     }

--- a/src/main/java/com/dnd/modutime/core/participant/application/ParticipantFacade.java
+++ b/src/main/java/com/dnd/modutime/core/participant/application/ParticipantFacade.java
@@ -39,6 +39,9 @@ public class ParticipantFacade {
 
     @Transactional
     public void joinAsOAuthUser(ParticipantJoinCommand command) {
+        if (command.getUserId() == null) {
+            throw new IllegalStateException("인증된 사용자의 ID가 없습니다.");
+        }
         if (queryService.existsByRoomUuidAndUserId(command.getRoomUuid(), command.getUserId())) {
             throw new IllegalArgumentException("이미 해당 방에 참여한 사용자입니다.");
         }

--- a/src/test/java/com/dnd/modutime/core/auth/oauth/facade/OAuth2TokenProviderTest.java
+++ b/src/test/java/com/dnd/modutime/core/auth/oauth/facade/OAuth2TokenProviderTest.java
@@ -1,9 +1,11 @@
 package com.dnd.modutime.core.auth.oauth.facade;
 
+import com.dnd.modutime.core.auth.oauth.OAuth2User;
 import com.dnd.modutime.core.auth.oauth.exception.InvalidOAuth2TokenException;
 import com.dnd.modutime.core.auth.security.TokenType;
 import com.dnd.modutime.core.common.ErrorCode;
 import com.dnd.modutime.core.user.OAuth2Provider;
+import com.dnd.modutime.core.user.User;
 import com.dnd.modutime.core.user.UserRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -13,13 +15,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserCache;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OAuth2TokenProvider 테스트")
@@ -31,6 +38,9 @@ class OAuth2TokenProviderTest {
 
     @Mock
     private UserCache userCache;
+
+    @Mock
+    private UserRepository userRepository;
 
     private static final String SECRET_KEY = "this-is-a-test-secret-key-for-testing-purposes-only";
     private static final String TEST_EMAIL = "test@example.com";
@@ -48,7 +58,7 @@ class OAuth2TokenProviderTest {
 
         oAuth2TokenProvider = new OAuth2TokenProvider(
                 tokenConfigurationProperties,
-                mock(UserRepository.class),
+                userRepository,
                 userCache
         );
     }
@@ -134,5 +144,46 @@ class OAuth2TokenProviderTest {
 
         // Then
         assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("loadAuthentication()에서 반환된 OAuth2User의 userId가 DB 조회값과 일치해야 한다")
+    void loadAuthentication에서_반환된_OAuth2User의_userId가_DB_조회값과_일치해야_한다() {
+        // Given
+        var provider = OAuth2Provider.KAKAO;
+        var accessToken = oAuth2TokenProvider.createOAuth2AccessToken(TEST_EMAIL, provider);
+
+        var user = new User("테스트", TEST_EMAIL, "profile.jpg", "thumb.jpg", provider);
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        when(userRepository.findByEmailAndProvider(TEST_EMAIL, provider))
+                .thenReturn(Optional.of(user));
+
+        // When
+        Authentication authentication = oAuth2TokenProvider.loadAuthentication(accessToken);
+        var principal = (OAuth2User) authentication.getPrincipal();
+
+        // Then
+        assertThat(principal.user().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("loadAuthentication()에서 캐시에 저장되어야 한다")
+    void loadAuthentication에서_캐시에_저장되어야_한다() {
+        // Given
+        var provider = OAuth2Provider.KAKAO;
+        var accessToken = oAuth2TokenProvider.createOAuth2AccessToken(TEST_EMAIL, provider);
+
+        var user = new User("테스트", TEST_EMAIL, "profile.jpg", "thumb.jpg", provider);
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        when(userRepository.findByEmailAndProvider(TEST_EMAIL, provider))
+                .thenReturn(Optional.of(user));
+
+        // When
+        oAuth2TokenProvider.loadAuthentication(accessToken);
+
+        // Then
+        verify(userCache).putUserInCache(any(OAuth2User.class));
     }
 }

--- a/src/test/java/com/dnd/modutime/core/participant/application/ParticipantFacadeTest.java
+++ b/src/test/java/com/dnd/modutime/core/participant/application/ParticipantFacadeTest.java
@@ -2,7 +2,11 @@ package com.dnd.modutime.core.participant.application;
 
 import com.dnd.modutime.annotations.SpringBootTestWithoutOAuthConfig;
 import com.dnd.modutime.core.participant.application.command.ParticipantCreateCommand;
+import com.dnd.modutime.core.participant.application.command.ParticipantJoinCommand;
 import com.dnd.modutime.core.room.application.RoomService;
+import com.dnd.modutime.core.user.OAuth2Provider;
+import com.dnd.modutime.core.user.User;
+import com.dnd.modutime.core.user.UserRepository;
 import com.dnd.modutime.exception.InvalidPasswordException;
 import com.dnd.modutime.util.IntegrationSupporter;
 import org.junit.jupiter.api.Test;
@@ -23,6 +27,9 @@ class ParticipantFacadeTest extends IntegrationSupporter {
 
     @Autowired
     private ParticipantQueryService queryService;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Test
     void 방에_존재하지_않는_이름과_패스워드로_로그인요청을_하면_새로운_참여자를_생성한다() {
@@ -52,5 +59,49 @@ class ParticipantFacadeTest extends IntegrationSupporter {
         assertThatThrownBy(() -> facade.login(command))
                 .isInstanceOf(InvalidPasswordException.class);
 
+    }
+
+    @Test
+    void OAuth_사용자가_방에_참여한다() {
+        // given
+        var roomUuid = roomService.create(getRoomRequest()).getUuid();
+        var user = userRepository.save(new User("테스트", "join-test@example.com", "profile", "thumb", OAuth2Provider.KAKAO));
+
+        // when
+        facade.joinAsOAuthUser(ParticipantJoinCommand.of(roomUuid, "테스트", user.getId()));
+
+        // then
+        var participant = queryService.findByRoomUuidAndUserId(roomUuid, user.getId());
+        assertThat(participant).isPresent();
+    }
+
+    @Test
+    void 이미_참여한_OAuth_사용자가_다시_참여하면_예외를_반환한다() {
+        // given
+        var roomUuid = roomService.create(getRoomRequest()).getUuid();
+        var user = userRepository.save(new User("테스트", "duplicate-test@example.com", "profile", "thumb", OAuth2Provider.KAKAO));
+        facade.joinAsOAuthUser(ParticipantJoinCommand.of(roomUuid, "테스트", user.getId()));
+
+        // when & then
+        var command = ParticipantJoinCommand.of(roomUuid, "다른이름", user.getId());
+        assertThatThrownBy(() -> facade.joinAsOAuthUser(command))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 해당 방에 참여한 사용자입니다.");
+    }
+
+    @Test
+    void 비로그인_참여자가_있는_방에_OAuth_사용자가_참여할_수_있다() {
+        // given
+        var roomUuid = roomService.create(getRoomRequest()).getUuid();
+        facade.login(ParticipantCreateCommand.of(roomUuid, "게스트", "1234"));
+
+        var user = userRepository.save(new User("OAuth유저", "oauth@example.com", "profile", "thumb", OAuth2Provider.KAKAO));
+
+        // when
+        facade.joinAsOAuthUser(ParticipantJoinCommand.of(roomUuid, "OAuth유저", user.getId()));
+
+        // then
+        var participant = queryService.findByRoomUuidAndUserId(roomUuid, user.getId());
+        assertThat(participant).isPresent();
     }
 }


### PR DESCRIPTION
## Summary
- main 브랜치에 push(머지)될 때 `release-yyyy-mm-dd-{buildNumber}` 형식의 태그를 자동 생성하는 워크플로우 추가
- 같은 날 여러 번 머지하면 buildNumber가 순차적으로 증가 (1, 2, 3, ...)

## Test plan
- [ ] main에 머지 후 Actions 탭에서 워크플로우 실행 확인
- [ ] 생성된 태그가 `release-yyyy-mm-dd-1` 형식인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 메인 브랜치 푸시 시 자동 릴리스 태그 생성 워크플로우 추가

* **Bug Fixes**
  * OAuth 사용자의 참여 검증 강화 및 오류 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->