### PR TITLE
ci: main 머지 시 release 태그 자동 생성

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,38 @@
+name: Create Release Tag
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Create release tag
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          PREFIX="release-${TODAY}"
+
+          LAST_BUILD=$(git tag -l "${PREFIX}-*" | sed "s/${PREFIX}-//" | sort -n | tail -1)
+
+          if [ -z "$LAST_BUILD" ]; then
+            BUILD_NUMBER=1
+          else
+            BUILD_NUMBER=$((LAST_BUILD + 1))
+          fi
+
+          TAG_NAME="${PREFIX}-${BUILD_NUMBER}"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
+          echo "### :label: Created tag: \`${TAG_NAME}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- main 브랜치에 push(머지)될 때 `release-yyyy-mm-dd-{buildNumber}` 형식의 태그를 자동 생성하는 워크플로우 추가
- 같은 날 여러 번 머지하면 buildNumber가 순차적으로 증가 (1, 2, 3, ...)

## Test plan
- [ ] main에 머지 후 Actions 탭에서 워크플로우 실행 확인
- [ ] 생성된 태그가 `release-yyyy-mm-dd-1` 형식인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)