### PR TITLE
ci: scp 배포 검증용 테스트 워크플로우 추가

### DIFF
--- a/.github/workflows/test-scp-deploy.yml
+++ b/.github/workflows/test-scp-deploy.yml
@@ -1,0 +1,177 @@
+name: 테스트 - scp 배포 검증
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: '배포할 브랜치를 입력합니다.'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+
+jobs:
+  test-scp-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # ──────────────────────────────────────
+      # 빌드 & Docker 이미지 Push
+      # ──────────────────────────────────────
+      - name: Build with Gradle
+        run: ./gradlew clean bootJar --info --build-cache -x test -Pinclude-api-docs
+
+      - name: Docker 이미지 빌드 및 Push
+        run: |
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker build -t ${{ secrets.DOCKER_REPO }}/modutime-web .
+          docker push ${{ secrets.DOCKER_REPO }}/modutime-web
+          docker build -t ${{ secrets.DOCKER_REPO }}/modutime-nginx ./nginx
+          docker push ${{ secrets.DOCKER_REPO }}/modutime-nginx
+
+      # ──────────────────────────────────────
+      # Green 인스턴스 생성
+      # ──────────────────────────────────────
+      - name: Green 인스턴스 생성
+        id: green
+        run: |
+          INSTANCE_ID=$(aws ec2 run-instances \
+            --launch-template LaunchTemplateId=${{ secrets.LAUNCH_TEMPLATE_ID }} \
+            --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=modutime-scp-test},{Key=DeployedBy,Value=github-actions-test}]' \
+            --query 'Instances[0].InstanceId' \
+            --output text)
+          echo "instance_id=$INSTANCE_ID" >> "$GITHUB_OUTPUT"
+          echo "Green 인스턴스 생성: $INSTANCE_ID"
+
+      - name: Green 인스턴스 실행 대기
+        run: |
+          aws ec2 wait instance-running \
+            --instance-ids ${{ steps.green.outputs.instance_id }}
+          echo "Green 인스턴스 running"
+
+      - name: Green 인스턴스 IP 확인
+        id: green_ip
+        run: |
+          PUBLIC_IP=$(aws ec2 describe-instances \
+            --instance-ids ${{ steps.green.outputs.instance_id }} \
+            --query 'Reservations[0].Instances[0].PublicIpAddress' \
+            --output text)
+          echo "public_ip=$PUBLIC_IP" >> "$GITHUB_OUTPUT"
+          echo "Green IP: $PUBLIC_IP"
+
+      # ──────────────────────────────────────
+      # SSH 키 설정 & 접속 대기
+      # ──────────────────────────────────────
+      - name: SSH 키 설정
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+
+      - name: Green SSH 접속 대기
+        run: |
+          echo "SSH 준비 대기 중..."
+          for i in $(seq 1 30); do
+            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 \
+              -i ~/.ssh/deploy_key ubuntu@${{ steps.green_ip.outputs.public_ip }} "echo ok" 2>/dev/null; then
+              echo "SSH 접속 성공!"
+              exit 0
+            fi
+            echo "대기 중... ($i/30)"
+            sleep 10
+          done
+          echo "SSH 접속 실패"
+          exit 1
+
+      # ──────────────────────────────────────
+      # scp로 필요 파일만 복사 & 앱 배포
+      # ──────────────────────────────────────
+      - name: Green 인스턴스에 필요 파일 복사 (scp)
+        run: |
+          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key \
+            ubuntu@${{ steps.green_ip.outputs.public_ip }} \
+            "mkdir -p /home/ubuntu/srv/ubuntu"
+          scp -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key \
+            docker-compose.yml install-docker.sh \
+            ubuntu@${{ steps.green_ip.outputs.public_ip }}:/home/ubuntu/srv/ubuntu/
+
+      - name: 복사된 파일 확인
+        run: |
+          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key \
+            ubuntu@${{ steps.green_ip.outputs.public_ip }} \
+            "echo '=== 복사된 파일 목록 ===' && ls -la /home/ubuntu/srv/ubuntu/"
+
+      - name: Green 인스턴스에 앱 배포
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ steps.green_ip.outputs.public_ip }}
+          username: ubuntu
+          key: ${{ secrets.KEY }}
+          command_timeout: 10m
+          script: |
+            cd /home/ubuntu/srv/ubuntu
+
+            cat > .env << EOL
+            DB_URL=${{ secrets.PROD_DB_URL }}
+            DB_USERNAME=${{ secrets.PROD_DB_USERNAME }}
+            DB_PASSWORD=${{ secrets.PROD_DB_PASSWORD }}
+            KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}
+            JWT_SECRET=${{ secrets.JWT_SECRET }}
+            EOL
+
+            sudo sh install-docker.sh
+            sudo docker pull ${{ secrets.DOCKER_REPO }}/modutime-web
+            sudo docker pull ${{ secrets.DOCKER_REPO }}/modutime-nginx
+            sudo docker-compose --env-file .env up -d
+
+      # ──────────────────────────────────────
+      # 헬스체크
+      # ──────────────────────────────────────
+      - name: Green 인스턴스 헬스체크
+        run: |
+          echo "헬스체크 시작 (최대 3분 대기, 경로: /aws)"
+          for i in $(seq 1 18); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              "http://${{ steps.green_ip.outputs.public_ip }}:80/aws" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "헬스체크 성공! scp 배포 검증 완료"
+              exit 0
+            fi
+            echo "대기 중... ($i/18, status=$STATUS)"
+            sleep 10
+          done
+          echo "헬스체크 실패"
+          exit 1
+
+      # ──────────────────────────────────────
+      # 테스트 완료 후 Green 정리 (항상 실행)
+      # ──────────────────────────────────────
+      - name: Green 인스턴스 정리
+        if: always()
+        run: |
+          if [ -n "${{ steps.green.outputs.instance_id }}" ]; then
+            echo "테스트 완료 - Green 인스턴스 정리: ${{ steps.green.outputs.instance_id }}"
+            aws ec2 terminate-instances \
+              --instance-ids ${{ steps.green.outputs.instance_id }}
+          fi

--- a/.github/workflows/test-scp-deploy.yml
+++ b/.github/workflows/test-scp-deploy.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Docker 이미지 빌드 및 Push
         run: |
-          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
           docker build -t ${{ secrets.DOCKER_REPO }}/modutime-web .
           docker push ${{ secrets.DOCKER_REPO }}/modutime-web
           docker build -t ${{ secrets.DOCKER_REPO }}/modutime-nginx ./nginx
@@ -120,7 +120,10 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key \
             ubuntu@${{ steps.green_ip.outputs.public_ip }} \
-            "echo '=== 복사된 파일 목록 ===' && ls -la /home/ubuntu/srv/ubuntu/"
+            "set -e; \
+             test -f /home/ubuntu/srv/ubuntu/docker-compose.yml; \
+             test -f /home/ubuntu/srv/ubuntu/install-docker.sh; \
+             echo '=== 복사된 파일 목록 ==='; ls -la /home/ubuntu/srv/ubuntu/"
 
       - name: Green 인스턴스에 앱 배포
         uses: appleboy/ssh-action@master


### PR DESCRIPTION
## Summary
- rsync 대신 scp로 필요한 파일만 복사하는 배포 방식이 정상 동작하는지 검증하는 테스트 워크플로우
- `docker-compose.yml`, `install-docker.sh` 2개만 scp로 복사
- 타겟 그룹 전환 없이 헬스체크까지 확인 후 인스턴스 자동 정리

## Test plan
- [ ] GitHub Actions에서 `테스트 - scp 배포 검증` 워크플로우 수동 실행
- [ ] 복사된 파일 확인 스텝에서 `docker-compose.yml`, `install-docker.sh` 존재 확인
- [ ] 헬스체크(/aws) 200 응답 확인
- [ ] 테스트 완료 후 Green 인스턴스 정리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 검증을 위한 자동화 워크플로우 추가

---

**참고:** 이 변경사항은 내부 인프라 개선으로, 최종 사용자 기능에 직접적인 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->