### PR TITLE
fix: AuthenticationException 핸들러를 GlobalControllerAdvice에 추가

### DIFF
--- a/src/main/java/com/dnd/modutime/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/dnd/modutime/advice/GlobalControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.dnd.modutime.advice;
 
 import com.dnd.modutime.advice.response.ExceptionResponse;
+import com.dnd.modutime.exception.AuthenticationException;
 import com.dnd.modutime.exception.InvalidPasswordException;
 import com.dnd.modutime.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
@@ -13,6 +14,12 @@ import java.net.BindException;
 
 @RestControllerAdvice
 public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ExceptionResponse> handleAuthenticationException(AuthenticationException exception) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ExceptionResponse(exception.getMessage()));
+    }
 
     @ExceptionHandler(InvalidPasswordException.class)
     public ResponseEntity<ExceptionResponse> handleUnAuthorizedException(InvalidPasswordException exception) {


### PR DESCRIPTION
## Summary
- `AuthenticationException` 하위 예외(BadCredentialsException, InvalidTokenException, UserNotFoundException, OAuth2AuthenticationException)가 `GlobalControllerAdvice`에서 처리되지 않아 Spring 기본 에러 처리로 빠지면서 ERROR 레벨 스택 트레이스가 대량 발생하는 문제 수정
- 상위 클래스인 `AuthenticationException`으로 잡아 4개 하위 예외를 모두 HTTP 401 UNAUTHORIZED로 처리

## Test plan
- [x] `./gradlew test` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 실패 시 HTTP 401 Unauthorized 응답과 함께 명확한 오류 메시지를 반환하도록 오류 처리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->