### PR TITLE
fix: 인증 예외별 개별 핸들러를 GlobalControllerAdvice에 추가

### DIFF
--- a/src/main/java/com/dnd/modutime/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/dnd/modutime/advice/GlobalControllerAdvice.java
@@ -1,6 +1,9 @@
 package com.dnd.modutime.advice;
 
 import com.dnd.modutime.advice.response.ExceptionResponse;
+import com.dnd.modutime.core.auth.oauth.facade.BadCredentialsException;
+import com.dnd.modutime.core.auth.oauth.facade.InvalidTokenException;
+import com.dnd.modutime.core.user.UserNotFoundException;
 import com.dnd.modutime.exception.InvalidPasswordException;
 import com.dnd.modutime.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
@@ -13,6 +16,24 @@ import java.net.BindException;
 
 @RestControllerAdvice
 public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ExceptionResponse> handleBadCredentialsException(BadCredentialsException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ExceptionResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleUserNotFoundException(UserNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ExceptionResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ExceptionResponse> handleInvalidTokenException(InvalidTokenException exception) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ExceptionResponse(exception.getMessage()));
+    }
 
     @ExceptionHandler(InvalidPasswordException.class)
     public ResponseEntity<ExceptionResponse> handleUnAuthorizedException(InvalidPasswordException exception) {


### PR DESCRIPTION
## Summary
- `AuthenticationException` 하위 예외가 `GlobalControllerAdvice`에서 처리되지 않아 500 + ERROR 스택 트레이스가 대량 발생하는 문제 수정
- 예외별 적절한 상태 코드로 개별 핸들러 추가:
  - `BadCredentialsException` → 400 (쿠키 미전송 등 클라이언트 오류)
  - `UserNotFoundException` → 400 (존재하지 않는 사용자 요청)
  - `InvalidTokenException` → 401 (만료된 토큰, 인증 실패)
- `OAuth2AuthenticationException`은 Spring Security 필터에서 이미 처리되므로 대상 아님

## Test plan
- [x] `./gradlew test` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 인증 실패, 사용자 미존재, 토큰 오류 등 예외 상황에 대해 적절한 HTTP 상태 코드(400 Bad Request, 401 Unauthorized)와 명확한 오류 메시지로 응답합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->