### PR TITLE
chore(sentry): BadCredentialsException 알림 필터 추가

### DIFF
--- a/src/main/java/com/dnd/modutime/config/SentryConfig.java
+++ b/src/main/java/com/dnd/modutime/config/SentryConfig.java
@@ -16,9 +16,11 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 @Configuration
 public class SentryConfig {
 
-    // 4xx 클라이언트 에러로 간주해 Sentry 알림에서 제외할 예외 목록.
-    // addIgnoredExceptionForType 만으로는 SentryExceptionResolver 가 캡처하는 예외를
-    // 일관되게 차단하지 못해, BeforeSendCallback 에서도 동일 목록으로 한 번 더 거른다.
+    /**
+     * 4xx 클라이언트 에러로 간주해 Sentry 알림에서 제외할 예외 목록.
+     * addIgnoredExceptionForType 만으로는 SentryExceptionResolver 가 캡처하는 예외를
+     * 일관되게 차단하지 못해, BeforeSendCallback 에서도 동일 목록으로 한 번 더 거른다.
+     */
     private static final List<Class<? extends Throwable>> IGNORED_EXCEPTIONS = List.of(
             IllegalArgumentException.class,
             NotFoundException.class,

--- a/src/main/java/com/dnd/modutime/config/SentryConfig.java
+++ b/src/main/java/com/dnd/modutime/config/SentryConfig.java
@@ -3,7 +3,9 @@ package com.dnd.modutime.config;
 import com.dnd.modutime.core.auth.oauth.facade.BadCredentialsException;
 import com.dnd.modutime.exception.InvalidPasswordException;
 import com.dnd.modutime.exception.NotFoundException;
+import io.sentry.Sentry;
 import io.sentry.SentryOptions;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -14,31 +16,38 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 @Configuration
 public class SentryConfig {
 
-    // application-sentry.yaml 의 ignored-exceptions-for-type 만으로는
-    // SentryExceptionResolver 가 캡처하는 4xx 예외를 일관되게 차단하지 못해,
-    // BeforeSendCallback 에서 한 번 더 명시적으로 거른다.
+    // 4xx 클라이언트 에러로 간주해 Sentry 알림에서 제외할 예외 목록.
+    // addIgnoredExceptionForType 만으로는 SentryExceptionResolver 가 캡처하는 예외를
+    // 일관되게 차단하지 못해, BeforeSendCallback 에서도 동일 목록으로 한 번 더 거른다.
+    private static final List<Class<? extends Throwable>> IGNORED_EXCEPTIONS = List.of(
+            IllegalArgumentException.class,
+            NotFoundException.class,
+            InvalidPasswordException.class,
+            BadCredentialsException.class,
+            MethodArgumentNotValidException.class,
+            HttpMessageNotReadableException.class,
+            BindException.class,
+            AccessDeniedException.class
+    );
+
     @Bean
-    public SentryOptions.BeforeSendCallback beforeSendCallback() {
-        return (event, hint) -> {
-            var ex = event.getThrowable();
-            if (ex == null) {
+    public Sentry.OptionsConfiguration<SentryOptions> sentryOptionsConfiguration() {
+        return options -> {
+            IGNORED_EXCEPTIONS.forEach(options::addIgnoredExceptionForType);
+            options.setBeforeSend((event, hint) -> {
+                var ex = event.getThrowable();
+                if (ex == null) {
+                    return event;
+                }
+                if (isIgnored(ex)) {
+                    return null;
+                }
                 return event;
-            }
-            if (isClientError(ex)) {
-                return null;
-            }
-            return event;
+            });
         };
     }
 
-    private boolean isClientError(Throwable ex) {
-        return ex instanceof IllegalArgumentException
-                || ex instanceof NotFoundException
-                || ex instanceof InvalidPasswordException
-                || ex instanceof BadCredentialsException
-                || ex instanceof MethodArgumentNotValidException
-                || ex instanceof HttpMessageNotReadableException
-                || ex instanceof BindException
-                || ex instanceof AccessDeniedException;
+    private boolean isIgnored(Throwable ex) {
+        return IGNORED_EXCEPTIONS.stream().anyMatch(type -> type.isInstance(ex));
     }
 }

--- a/src/main/java/com/dnd/modutime/config/SentryConfig.java
+++ b/src/main/java/com/dnd/modutime/config/SentryConfig.java
@@ -1,5 +1,6 @@
 package com.dnd.modutime.config;
 
+import com.dnd.modutime.core.auth.oauth.facade.BadCredentialsException;
 import com.dnd.modutime.exception.InvalidPasswordException;
 import com.dnd.modutime.exception.NotFoundException;
 import io.sentry.SentryOptions;
@@ -34,6 +35,7 @@ public class SentryConfig {
         return ex instanceof IllegalArgumentException
                 || ex instanceof NotFoundException
                 || ex instanceof InvalidPasswordException
+                || ex instanceof BadCredentialsException
                 || ex instanceof MethodArgumentNotValidException
                 || ex instanceof HttpMessageNotReadableException
                 || ex instanceof BindException

--- a/src/main/resources/application-sentry.yaml
+++ b/src/main/resources/application-sentry.yaml
@@ -18,6 +18,7 @@ sentry:
   ignored-exceptions-for-type:
     - com.dnd.modutime.exception.NotFoundException
     - com.dnd.modutime.exception.InvalidPasswordException
+    - com.dnd.modutime.core.auth.oauth.facade.BadCredentialsException
     - org.springframework.security.access.AccessDeniedException
     - org.springframework.web.bind.MethodArgumentNotValidException
     - java.lang.IllegalArgumentException

--- a/src/main/resources/application-sentry.yaml
+++ b/src/main/resources/application-sentry.yaml
@@ -15,12 +15,4 @@ sentry:
   send-default-pii: false
   in-app-includes: com.dnd.modutime
   exception-resolver-order: -2147483647
-  ignored-exceptions-for-type:
-    - com.dnd.modutime.exception.NotFoundException
-    - com.dnd.modutime.exception.InvalidPasswordException
-    - com.dnd.modutime.core.auth.oauth.facade.BadCredentialsException
-    - org.springframework.security.access.AccessDeniedException
-    - org.springframework.web.bind.MethodArgumentNotValidException
-    - java.lang.IllegalArgumentException
-    - org.springframework.validation.BindException
-    - org.springframework.http.converter.HttpMessageNotReadableException
+  # 무시할 예외 목록은 SentryConfig.IGNORED_EXCEPTIONS 에서 일괄 관리한다.


### PR DESCRIPTION
## Summary
- OAuth 토큰 검증 실패로 발생하는 `com.dnd.modutime.core.auth.oauth.facade.BadCredentialsException`은 4xx 클라이언트 에러이므로 Sentry 알림에서 제외
- 기존 `InvalidPasswordException` 등과 동일한 패턴으로 `application-sentry.yaml`의 `ignored-exceptions-for-type`과 `SentryConfig#beforeSendCallback` 양쪽에 모두 등록 (둘 중 어느 경로로 캡처되더라도 일관되게 무시되도록)

## Test plan
- [x] `./gradlew compileJava` 통과
- [ ] 운영 배포 후 Sentry 대시보드에서 `BadCredentialsException` 신규 이벤트가 더 이상 들어오지 않는지 확인