### PR TITLE
chore: CI 테스트 로그에서 Hibernate SQL 출력 억제

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
       - name: Build with gradle
-        run: ./gradlew clean test --info --build-cache
+        run: ./gradlew clean test --build-cache
 
       #https://github.com/actions/upload-artifact
       - name: "Upload failure test report"

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,11 +1,16 @@
 spring:
   jpa:
-    show-sql: true
+    # 로컬에서 SQL 보고 싶으면 환경변수로 켠다 (Gradle -D는 test worker로 전파되지 않음):
+    #   SPRING_JPA_SHOW_SQL=true \
+    #   SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL=true \
+    #   LOGGING_LEVEL_ORG_HIBERNATE_TYPE_DESCRIPTOR_SQL_BASICBINDER=TRACE \
+    #   ./gradlew test
+    show-sql: false
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
     generate-ddl: true
   datasource:
     url:
@@ -44,12 +49,9 @@ spring:
 
 logging:
   level:
-    org:
-      hibernate:
-        type:
-          descriptor:
-            sql:
-              BasicBinder: TRACE
+    org.hibernate.SQL: WARN
+    org.hibernate.type.descriptor.sql.BasicBinder: WARN
+    org.hibernate.tool.hbm2ddl: WARN
 
 
 modutime:


### PR DESCRIPTION
## Summary
- CI Pull Request 워크플로우의 콘솔 로그가 Hibernate `show-sql` + `BasicBinder TRACE` 조합으로 폭증하던 문제 해결
- `src/test/resources/application.yaml`에서 SQL 출력 관련 키를 모두 OFF로 기본화하고 hbm2ddl/SQL 로거를 WARN으로 명시
- `.github/workflows/ci-pull-request.yml`에서 `--info` 플래그 제거 (Gradle test worker 로그 forwarding 차단)

## 동작
| 환경 | 명령 | SQL 출력 |
|---|---|---|
| CI / 로컬 기본 | `./gradlew test` | 없음 |
| 로컬 SQL 디버깅 | `SPRING_JPA_SHOW_SQL=true SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL=true LOGGING_LEVEL_ORG_HIBERNATE_TYPE_DESCRIPTOR_SQL_BASICBINDER=TRACE ./gradlew test` | 전체 |

> ⚠️ `gradle -D...` 시스템 프로퍼티는 test worker(별도 fork JVM)로 전파되지 않음. 환경변수만 동작. 사용법은 `application.yaml` 상단 주석에 명시.

## Test plan
- [x] 로컬에서 `./gradlew test --tests "...RoomIntegrationTest"` 실행 → BUILD SUCCESSFUL, `Hibernate:` 라인 0줄
- [x] 환경변수 켜고 동일 명령 → BUILD SUCCESSFUL, `Hibernate:` 라인 53줄 (정상 출력 확인)
- [ ] 머지 후 후속 PR CI에서 로그 라인 수가 기존 대비 80%+ 감소했는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)