### PR TITLE
fix: 방 생성 빈 본문 500 → 400 통일 + advice 4xx 핸들러 보강

### DIFF
--- a/src/main/java/com/dnd/modutime/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/dnd/modutime/advice/GlobalControllerAdvice.java
@@ -8,7 +8,9 @@ import com.dnd.modutime.exception.NotFoundException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
@@ -35,6 +37,24 @@ public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException exception) {
         return build(HttpStatus.BAD_REQUEST, ErrorCode.MT400, exception);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatus status,
+                                                                  WebRequest request) {
+        return handleBindException(ex, headers, status, request);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatus status,
+                                                                  WebRequest request) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.from(ErrorCode.MT400, ErrorCode.MT400.getDescription(),
+                        HttpStatus.BAD_REQUEST.value()));
     }
 
     @Override

--- a/src/main/java/com/dnd/modutime/core/room/application/RoomService.java
+++ b/src/main/java/com/dnd/modutime/core/room/application/RoomService.java
@@ -31,13 +31,16 @@ public class RoomService {
 
     public RoomCreationResponse create(RoomRequest roomRequest) {
         TimerRequest timerRequest = roomRequest.getTimerRequest();
+        List<RoomDate> roomDates = roomRequest.getDates() == null
+                ? null
+                : roomRequest.getDates().stream()
+                        .map(RoomDate::new)
+                        .collect(Collectors.toList());
         Room room = new Room(
                 roomRequest.getTitle(),
                 roomRequest.getStartTime(),
                 roomRequest.getEndTime(),
-                roomRequest.getDates().stream()
-                        .map(RoomDate::new)
-                        .collect(Collectors.toList()),
+                roomDates,
                 roomRequest.getHeadCount(),
                 findDeadLineOrNull(timerRequest),
                 timeProvider);

--- a/src/main/java/com/dnd/modutime/core/room/application/request/RoomRequest.java
+++ b/src/main/java/com/dnd/modutime/core/room/application/request/RoomRequest.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,9 +17,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RoomRequest {
 
+    @NotBlank(message = "방의 제목은 빈문자일 수 없습니다.")
     private String title;
     private Integer headCount;
 
+    @NotEmpty(message = "날짜는 최소 1개이상 존재해야 합니다.")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private List<LocalDate> dates;
 

--- a/src/main/java/com/dnd/modutime/core/room/controller/RoomController.java
+++ b/src/main/java/com/dnd/modutime/core/room/controller/RoomController.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 public class RoomController {
@@ -21,7 +23,7 @@ public class RoomController {
 
     @Deprecated(since = "카카오 로그인 배포 이후")
     @PostMapping("/api/room")
-    public ResponseEntity<RoomCreationResponse> create(@RequestBody RoomRequest roomRequest) {
+    public ResponseEntity<RoomCreationResponse> create(@RequestBody @Valid RoomRequest roomRequest) {
         RoomCreationResponse roomCreationResponse = roomService.create(roomRequest);
         timeTableService.create(roomCreationResponse.getUuid());
         adjustmentResultService.create(roomCreationResponse.getUuid());

--- a/src/main/java/com/dnd/modutime/core/room/controller/RoomGuestController.java
+++ b/src/main/java/com/dnd/modutime/core/room/controller/RoomGuestController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 public class RoomGuestController {
@@ -19,7 +21,7 @@ public class RoomGuestController {
     private final AdjustmentResultService adjustmentResultService;
 
     @PostMapping("/guest/api/room")
-    public ResponseEntity<RoomCreationResponse> create(@RequestBody RoomRequest roomRequest) {
+    public ResponseEntity<RoomCreationResponse> create(@RequestBody @Valid RoomRequest roomRequest) {
         RoomCreationResponse roomCreationResponse = roomService.create(roomRequest);
         timeTableService.create(roomCreationResponse.getUuid());
         adjustmentResultService.create(roomCreationResponse.getUuid());

--- a/src/test/java/com/dnd/modutime/acceptance/RoomAcceptanceTest.java
+++ b/src/test/java/com/dnd/modutime/acceptance/RoomAcceptanceTest.java
@@ -5,13 +5,17 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 import com.dnd.modutime.acceptance.request.RoomRequestWithNoNull;
 import com.dnd.modutime.core.room.application.response.RoomCreationResponse;
 import com.dnd.modutime.core.room.application.response.V2RoomInfoResponse;
 
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
@@ -69,5 +73,65 @@ public class RoomAcceptanceTest extends AcceptanceSupporter{
                 "이멤버리멤버",
                 List.of(_2023_02_10)));
         return response.body().as(RoomCreationResponse.class);
+    }
+
+    @Test
+    void 빈_본문으로_방_생성_요청시_400을_응답한다() {
+        ExtractableResponse<Response> response = postRaw("/api/room", "{}");
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+                () -> assertThat(response.jsonPath().getString("message")).isNotBlank()
+        );
+    }
+
+    @Test
+    void 깨진_JSON으로_방_생성_요청시_400을_응답한다() {
+        ExtractableResponse<Response> response = postRaw("/api/room", "{");
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("잘못된 요청입니다.")
+        );
+    }
+
+    @Test
+    void 제목이_없으면_400을_응답한다() {
+        Map<String, Object> body = Map.of(
+                "dates", List.of("2023-02-10"),
+                "headCount", 5
+        );
+
+        ExtractableResponse<Response> response = post("/api/room", body);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("방의 제목은 빈문자일 수 없습니다.")
+        );
+    }
+
+    @Test
+    void 날짜가_비어있으면_400을_응답한다() {
+        Map<String, Object> body = Map.of(
+                "title", "이멤버리멤버",
+                "dates", List.of(),
+                "headCount", 5
+        );
+
+        ExtractableResponse<Response> response = post("/api/room", body);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+                () -> assertThat(response.jsonPath().getString("message")).isEqualTo("날짜는 최소 1개이상 존재해야 합니다.")
+        );
+    }
+
+    private ExtractableResponse<Response> postRaw(String uri, String body) {
+        return RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post(uri)
+                .then().log().all()
+                .extract();
     }
 }

--- a/src/test/java/com/dnd/modutime/controller/room/RoomGuestControllerDocsTest.java
+++ b/src/test/java/com/dnd/modutime/controller/room/RoomGuestControllerDocsTest.java
@@ -59,12 +59,14 @@ public class RoomGuestControllerDocsTest {
 
         var requestFields = new FieldDescriptor[]{
                 fieldWithPath("title").type(STRING).description("방 제목"),
-                fieldWithPath("roomDates").type(ARRAY).description("방 날짜 목록"),
-                fieldWithPath("roomDates[].availableDate").type(STRING).description("날짜"),
-                fieldWithPath("roomDates[].availableTimes").type(ARRAY).description("시간 목록").optional(),
-                fieldWithPath("roomDates[].availableTimes[].startTime").type(STRING).description("시작 시간").optional(),
-                fieldWithPath("roomDates[].availableTimes[].endTime").type(STRING).description("종료 시간").optional(),
-                fieldWithPath("headcount").type(NUMBER).description("예상 인원"),
+                fieldWithPath("headCount").type(NUMBER).description("예상 인원").optional(),
+                fieldWithPath("dates").type(ARRAY).description("방 날짜 목록 (yyyy-MM-dd)"),
+                fieldWithPath("startTime").type(STRING).description("시작 시간 (HH:mm)").optional(),
+                fieldWithPath("endTime").type(STRING).description("종료 시간 (HH:mm)").optional(),
+                fieldWithPath("timer").type(OBJECT).description("마감 타이머").optional(),
+                fieldWithPath("timer.day").type(NUMBER).description("마감 일 수").optional(),
+                fieldWithPath("timer.hour").type(NUMBER).description("마감 시간").optional(),
+                fieldWithPath("timer.minute").type(NUMBER).description("마감 분").optional(),
         };
 
         var responseFields = new FieldDescriptor[]{
@@ -75,18 +77,15 @@ public class RoomGuestControllerDocsTest {
         var requestLiteral = """
                 {
                   "title": "모두의 회의",
-                  "roomDates": [
-                    {
-                      "availableDate": "2025-07-16",
-                      "availableTimes": [
-                        {
-                          "startTime": "13:00",
-                          "endTime": "15:00"
-                        }
-                      ]
-                    }
-                  ],
-                  "headcount": 5
+                  "headCount": 5,
+                  "dates": ["2025-07-16"],
+                  "startTime": "13:00",
+                  "endTime": "15:00",
+                  "timer": {
+                    "day": 2,
+                    "hour": 1,
+                    "minute": 30
+                  }
                 }
                 """;
 


### PR DESCRIPTION
## Summary

- `POST /api/room` / `POST /guest/api/room`에 빈 본문 `{}`을 보내면 `RoomService.create()`에서 `getDates().stream()` NPE로 500을 던지던 문제 수정 — 도메인 검증으로 위임해 400 반환
- `RoomRequest`에 `@NotBlank title` / `@NotEmpty dates` 부착 + 두 컨트롤러에 `@Valid` 추가 → 의도된 400 + 명확한 메시지
- `GlobalControllerAdvice`에 `handleMethodArgumentNotValid` / `handleHttpMessageNotReadable` 오버라이드 추가 → 이미 `@Valid` 사용 중인 다른 12개 컨트롤러의 검증/파싱 실패 응답이 일괄 `{"message":"..."}` 형식으로 통일 (이전: 빈 바디 400)
- 사전 불일치 상태였던 `RoomGuestControllerDocsTest` 요청 본문/필드를 실제 `RoomRequest` 스키마(`title`/`dates`/`headCount`/`startTime`/`endTime`/`timer`)에 맞춰 정렬 — `@Valid` 도입으로 드러난 기존 docs 잘못 반영

## Background

- 원인: `RoomService.create()` (`RoomService.java:38`)의 `roomRequest.getDates().stream()`가 null-체크 없이 호출됨. 빈 본문 `{}` → Jackson이 `dates`를 null로 두고 → 서비스 레이어 NPE → `@ExceptionHandler(Exception.class)` 매칭 → 500 (MT500).
- 구조적 공백: `GlobalControllerAdvice`가 `ResponseEntityExceptionHandler`를 상속하지만 `MethodArgumentNotValid`/`HttpMessageNotReadable`를 오버라이드하지 않아 검증 실패 시 Spring 기본 동작(빈 바디 400)이 새고 있었음.
- Sentry: 두 예외 모두 이미 `SentryConfig.IGNORED_EXCEPTIONS`에 등록되어 있어 별도 작업 없이도 알림 차단 유지.

## Out of scope (다음 PR 후보)

- `ExceptionResponse`(message only) → `ErrorResponse`(code/message/status)로의 전면 마이그레이션
- `TimerRequest` 내부 필드 Bean Validation
- 다른 `@Valid` 컨트롤러들의 검증 메시지 표준화

## Test plan

- [x] `./gradlew test` (357 tests, 0 failures)
- [x] `./gradlew apiDocsTest`
- [x] `RoomAcceptanceTest`에 4개 케이스 추가 (빈 본문 / 깨진 JSON / 제목 누락 / 빈 dates → 모두 400 + 메시지 검증)
- [ ] 운영 배포 후 빈 본문 `{}` 요청이 400으로 응답하는지 한 번 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 방 생성 요청 시 입력값 검증 추가: 제목은 필수이며 날짜는 최소 1개 이상 필요

* **버그 수정**
  * 빈 요청 본문, 손상된 JSON, 누락된 필드에 대한 명확한 400 오류 응답 처리 개선
  * Null 날짜 입력 처리 개선

* **테스트**
  * 입력값 검증 시나리오에 대한 새로운 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnd-side-project/dnd-8th-5-backend/pull/164)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->