### PR TITLE
docs(auth): 네이티브 카카오 로그인 adoc include 보강 + API 문서화 가이드 분리

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -150,9 +150,9 @@ Event handlers use `@Transactional(propagation = Propagation.REQUIRES_NEW)` for 
 **TDD is mandatory** - write tests before implementation:
 
 1. **API Documentation Tests** - Required for all controller endpoints
-   - Tag with `@ApiDocsTest`
-   - Generate REST Docs snippets
-   - Located in `src/test/java/.../controller/`
+   - Tag with `@ApiDocsTest`, located in `src/test/java/.../controller/`
+   - **주의:** 스니펫 생성만으로는 사용자 HTML에 노출되지 않는다. `src/docs/asciidoc/{도메인}.adoc`에 `include::{snippets}/...`까지 추가해야 한다.
+   - 상세 단계 + 체크리스트: [docs/api-documentation.md](docs/api-documentation.md)
 
 2. **Acceptance Tests** - End-to-end API tests
    - Extend `AcceptanceSupporter` base class
@@ -191,16 +191,9 @@ adr new {decision-name}
 
 ## API Documentation
 
-The project generates two types of API documentation:
+API 문서화는 **Spring REST Docs (AsciiDoc → HTML)** 와 **OpenAPI 3.0 (YAML)** 두 가지를 동시에 생성한다. 두 산출물 모두 `@ApiDocsTest` 한 곳에서 파생되지만, REST Docs HTML 노출에는 `src/docs/asciidoc/*.adoc` 의 include 갱신이 추가로 필요하다.
 
-1. **Spring REST Docs** (AsciiDoc format)
-   - Generated from controller tests tagged with `@ApiDocsTest`
-   - Output: `build/docs/asciidoc/`
-   - Included in JAR when building with `-Pinclude-api-docs`
-
-2. **OpenAPI 3.0 Spec** (YAML format)
-   - Generated via `openapi3` Gradle task
-   - Uses `restdocs-api-spec` plugin
+전체 파이프라인, 신규 엔드포인트 체크리스트, 자주 발생하는 실수 사례는 [docs/api-documentation.md](docs/api-documentation.md) 를 참고한다.
 
 ## Working with the Codebase
 
@@ -210,8 +203,9 @@ The project generates two types of API documentation:
 2. Start with domain model changes (entities, value objects)
 3. Write domain unit tests first
 4. Implement service layer logic
-5. Add controller endpoint with `@ApiDocsTest`
-6. If cross-aggregate coordination needed, use domain events
+5. Add controller endpoint with `@ApiDocsTest` (스니펫 생성)
+6. **`src/docs/asciidoc/{도메인}.adoc` 에 새 operationId의 include 블록 추가** — 빼먹기 쉬움, [docs/api-documentation.md](docs/api-documentation.md) 체크리스트 참고
+7. If cross-aggregate coordination needed, use domain events
 
 ### Understanding Time Adjustment Logic
 

--- a/.claude/docs/api-documentation.md
+++ b/.claude/docs/api-documentation.md
@@ -1,0 +1,85 @@
+# API Documentation Guide
+
+Spring REST Docs + OpenAPI 3.0 으로 API 문서를 자동 생성한다. 이 문서는 신규/변경 엔드포인트를 추가할 때 빠뜨리기 쉬운 단계를 명시한다.
+
+## 2단계 파이프라인 (중요)
+
+REST Docs 문서화는 **두 단계**다. 두 단계 모두 갱신해야 사용자가 보는 HTML 에 노출된다.
+
+```
+@ApiDocsTest 클래스 실행
+       │
+       ▼  ./gradlew apiDocsTest
+build/generated-snippets/{operationId}/*.adoc      ← 1단계: 스니펫 생성
+       │
+       ▼  ./gradlew asciidoctor
+src/docs/asciidoc/{도메인}.adoc 의 include::{snippets}/{operationId}/... 라인이 끌어옴
+       │
+       ▼
+build/docs/asciidoc/*.html                         ← 2단계: 사용자가 보는 문서
+```
+
+**자주 발생하는 실수:** 1단계만 하고 2단계를 빼먹는다. `apiDocsTest` 는 스니펫만 검증하고 통과하며, `asciidoctor` 는 "없는 스니펫을 include 하면" 실패하지만 "있는 스니펫을 include 안 한 경우" 는 침묵하기 때문에 CI 로도 안 잡힌다. 사례: PR #165 (commit `054ac3b`) — DocsTest 는 추가됐지만 `src/docs/asciidoc/auth-oauth2.adoc` include 가 빠져 두 신규 operation 이 HTML 에서 누락됨.
+
+## 신규/변경 엔드포인트 추가 시 체크리스트
+
+1. **컨트롤러에 `@ApiDocsTest` 추가**
+   - 파일: `src/test/java/com/dnd/modutime/controller/{도메인}/{Controller}DocsTest.java`
+   - `MockMvcFactory.getRestDocsMockMvc(...)` 로 호출
+   - `MockMvcRestDocumentation.document(operationId, ...)` 와 `MockMvcRestDocumentationWrapper.document(...)` 를 함께 호출 (REST Docs + OpenAPI 동시 생성)
+   - `operationId` 컨벤션: `{도메인}-{method}-{path-kebab}` 예: `oauth2-post-kakao-native-login`
+
+2. **adoc include 추가**
+   - 파일: `src/docs/asciidoc/{도메인}.adoc`
+   - 같은 도메인 파일이 없으면 새로 만들고 `src/docs/asciidoc/index.adoc` 에 `include::{도메인}.adoc[]` 추가
+   - 기본 패턴:
+     ```adoc
+     === {기능 이름}
+
+     * 한 줄 설명
+     * 실패 응답 (4xx/5xx) 목록 (있다면)
+
+     [discrete]
+     ==== 요청
+
+     include::{snippets}/{operationId}/curl-request.adoc[]
+     include::{snippets}/{operationId}/http-request.adoc[]
+     include::{snippets}/{operationId}/path-parameters.adoc[]     // 있을 때만
+     include::{snippets}/{operationId}/request-parameters.adoc[]  // 있을 때만
+     include::{snippets}/{operationId}/request-headers.adoc[]     // 있을 때만
+     include::{snippets}/{operationId}/request-fields.adoc[]      // JSON 바디일 때
+
+     [discrete]
+     ==== 응답
+
+     include::{snippets}/{operationId}/http-response.adoc[]
+     include::{snippets}/{operationId}/response-fields.adoc[]
+     ```
+
+3. **검증**
+   ```bash
+   export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+   ./gradlew apiDocsTest asciidoctor
+   ```
+   - `build/generated-snippets/{operationId}/` 에 9개 파일이 생겼는지
+   - `build/docs/asciidoc/index.html` 에 새 섹션이 렌더링됐는지
+
+## Gradle 태스크 레퍼런스
+
+| 명령 | 역할 |
+|---|---|
+| `./gradlew apiDocsTest` | `@ApiDocsTest` 만 실행 → 스니펫 생성 |
+| `./gradlew asciidoctor` | adoc → HTML 빌드 (`build/docs/asciidoc/`) |
+| `./gradlew openapi3` | OpenAPI 3.0 YAML 생성 (`restdocs-api-spec` 플러그인) |
+| `./gradlew bootJar -Pinclude-api-docs` | API 문서를 JAR 에 포함해서 빌드 |
+
+## 출력 위치
+
+- 스니펫 (중간 산출물): `build/generated-snippets/{operationId}/*.adoc`
+- HTML (사용자 가시): `build/docs/asciidoc/{도메인}.html`, `index.html`
+- OpenAPI YAML: `build/api-spec/openapi3.yaml`
+
+## ADR
+
+- 결정: API 문서화는 Spring REST Docs 를 사용한다 (컨트롤러 테스트가 강제됨)
+- 자세한 내용: `architecture-decision-records/` 참고

--- a/src/docs/asciidoc/auth-oauth2.adoc
+++ b/src/docs/asciidoc/auth-oauth2.adoc
@@ -20,22 +20,61 @@ include::{snippets}/oauth2-get-authorization-registration-id/request-parameters.
 include::{snippets}/oauth2-get-authorization-registration-id/http-response.adoc[]
 include::{snippets}/oauth2-get-authorization-registration-id/response-fields.adoc[]
 
-=== 토큰 재발급
+=== 네이티브 카카오 로그인
 
-* refreshToken 쿠키를 이용하여 새로운 accessToken을 발급합니다.
-* 요청 시 `Cookie: refreshToken={리프레시 토큰}` 헤더를 포함해야 합니다.
+* 네이티브 앱(iOS/Android)이 카카오 SDK 로 발급받은 사용자 access token 으로 자체 JWT(액세스/리프레시)를 JSON 응답으로 발급합니다.
+* 쿠키를 사용하지 않으므로 키체인/Keystore 등 앱 저장소를 가진 네이티브 환경에 적합합니다. 웹 흐름은 기존 `GET /oauth2/authorization/{registrationId}` 를 그대로 사용하세요.
+* 실패 응답:
+** `401 Unauthorized` - 유효하지 않은 카카오 access token (`INVALID_KAKAO_TOKEN`)
+** `403 Forbidden` - 카카오 계정 이메일 제공에 동의하지 않음 (`KAKAO_EMAIL_NOT_PROVIDED`)
+** `500 Internal Server Error` - 카카오 API 호출 자체가 실패한 경우 (`KAKAO_API_ERROR`)
 
 [discrete]
 ==== 요청
+
+include::{snippets}/oauth2-post-kakao-native-login/curl-request.adoc[]
+include::{snippets}/oauth2-post-kakao-native-login/http-request.adoc[]
+include::{snippets}/oauth2-post-kakao-native-login/request-fields.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/oauth2-post-kakao-native-login/http-response.adoc[]
+include::{snippets}/oauth2-post-kakao-native-login/response-fields.adoc[]
+
+=== 토큰 재발급
+
+* refreshToken 으로 새로운 accessToken 을 발급합니다.
+* 입력 경로는 두 가지를 동시에 지원합니다.
+** 웹: `Cookie: refreshToken={리프레시 토큰}` 헤더
+** 네이티브 앱: JSON 바디 `{ "refreshToken": "..." }`
+* 우선순위는 `body.refreshToken` (비어있지 않을 때) > 쿠키 입니다.
+* 쿠키와 바디 모두 비어있으면 `401 Unauthorized` 가 반환됩니다.
+
+[discrete]
+==== 요청 - 쿠키
 
 include::{snippets}/oauth2-post-reissue-token/curl-request.adoc[]
 include::{snippets}/oauth2-post-reissue-token/http-request.adoc[]
 
 [discrete]
-==== 응답
+==== 응답 - 쿠키
 
 include::{snippets}/oauth2-post-reissue-token/http-response.adoc[]
 include::{snippets}/oauth2-post-reissue-token/response-fields.adoc[]
+
+[discrete]
+==== 요청 - JSON 바디 (네이티브 앱)
+
+include::{snippets}/oauth2-post-reissue-token-with-body/curl-request.adoc[]
+include::{snippets}/oauth2-post-reissue-token-with-body/http-request.adoc[]
+include::{snippets}/oauth2-post-reissue-token-with-body/request-fields.adoc[]
+
+[discrete]
+==== 응답 - JSON 바디 (네이티브 앱)
+
+include::{snippets}/oauth2-post-reissue-token-with-body/http-response.adoc[]
+include::{snippets}/oauth2-post-reissue-token-with-body/response-fields.adoc[]
 
 === 로그아웃
 


### PR DESCRIPTION
## Summary

- PR #165 (`054ac3b`) 에서 신규/확장 엔드포인트의 `@ApiDocsTest` 는 추가됐지만, 생성된 스니펫을 사용자 HTML 로 노출하는 `src/docs/asciidoc/auth-oauth2.adoc` include 가 누락돼 두 operation 이 문서에서 사라졌던 회귀를 복구
- 같은 누락이 재발하지 않도록 `.claude/CLAUDE.md` 의 API 문서화 가이드를 별도 문서로 분리하고 부족하던 단계(adoc include)를 명시

## Changes

### `src/docs/asciidoc/auth-oauth2.adoc`
- 신규 "네이티브 카카오 로그인" 섹션 — `oauth2-post-kakao-native-login` 스니펫 include + 401/403/500 케이스 설명
- "토큰 재발급" 섹션을 쿠키 / JSON 바디 두 입력 경로로 재구성 — `oauth2-post-reissue-token-with-body` 스니펫 include, 우선순위(`body.refreshToken` > cookie) 명시

### `.claude/CLAUDE.md` + `.claude/docs/api-documentation.md` (신규)
- API 문서화 상세 가이드를 `.claude/docs/api-documentation.md` 로 분리
  - 2단계 파이프라인(스니펫 생성 → adoc include) 명시
  - PR #165 누락 사례를 anti-pattern 으로 인용
  - 신규/변경 엔드포인트 체크리스트, Gradle 태스크 / 출력 위치 레퍼런스
- CLAUDE.md 본문은 인덱스 링크 + 한 줄 요약으로 축소
- "Adding a New Feature" 단계에 "6. `src/docs/asciidoc/{도메인}.adoc` 에 include 추가" 명시

## Root cause of PR #165 docs miss

REST Docs 는 2단계 파이프라인:
1. `@ApiDocsTest` → `build/generated-snippets/{opId}/*.adoc`
2. `src/docs/asciidoc/*.adoc` 의 `include::{snippets}/...` → HTML

`apiDocsTest` 는 1단계만 검증해 통과하고, `asciidoctor` 는 "없는 스니펫 include" 에서만 실패하며 "있는 스니펫을 include 안한 경우" 는 침묵해 CI 로도 못 잡음. CLAUDE.md 가이던스에도 2단계 언급이 없어 빠뜨리기 쉬웠음.

## Test plan

- [x] `./gradlew apiDocsTest asciidoctor` BUILD SUCCESSFUL
- [x] `build/generated-snippets/oauth2-post-kakao-native-login/` + `oauth2-post-reissue-token-with-body/` 스니펫 생성 확인
- [x] `build/docs/asciidoc/index.html` 에 두 신규 섹션 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 문서화 가이드를 추가하여 REST Docs 및 OpenAPI 워크플로우를 명확히 설명했습니다.
  * OAuth2 인증 문서를 개선하여 네이티브 카카오 로그인 흐름을 추가했습니다.
  * 토큰 재발급 기능이 쿠키와 JSON 바디 두 가지 방식을 모두 지원하도록 문서화했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnd-side-project/dnd-8th-5-backend/pull/166)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->