### PR TITLE
feat(admin): 어드민 대시보드 메트릭 API 추가

### DIFF
--- a/db/migrations/V20260614_3_CREATE_METRICS_INDEXES.sql
+++ b/db/migrations/V20260614_3_CREATE_METRICS_INDEXES.sql
@@ -1,0 +1,35 @@
+# 요약: 어드민 대시보드 메트릭 집계(생성일시 범위 / 활성 방) 성능 인덱스 추가 — 멱등(이미 있으면 건너뜀)
+---
+-- MySQL 은 CREATE INDEX IF NOT EXISTS 를 지원하지 않으므로, information_schema 로 존재 여부를
+-- 확인해 없을 때만 생성한다. (일부 인덱스가 이미 존재하거나 부분 적용된 환경에서도 안전하게 재실행 가능)
+
+-- 방 생성 추이 + 최근 7일 신규 방(newRoomsLast7d): room.created_at 범위 스캔
+SET @ddl := IF(
+    (SELECT COUNT(*) FROM information_schema.statistics
+     WHERE table_schema = DATABASE() AND table_name = 'room' AND index_name = 'idx_room_created_at') = 0,
+    'CREATE INDEX idx_room_created_at ON room (created_at)', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- 참여자 추이(전체) + 게스트 추이(user_id IS NULL 잔여 필터): participant.created_at 범위 스캔
+SET @ddl := IF(
+    (SELECT COUNT(*) FROM information_schema.statistics
+     WHERE table_schema = DATABASE() AND table_name = 'participant' AND index_name = 'idx_participant_created_at') = 0,
+    'CREATE INDEX idx_participant_created_at ON participant (created_at)', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- 활성 방(activeRooms): modified_at 범위 + room_uuid distinct 커버링 복합 인덱스
+SET @ddl := IF(
+    (SELECT COUNT(*) FROM information_schema.statistics
+     WHERE table_schema = DATABASE() AND table_name = 'time_block' AND index_name = 'idx_time_block_modified_at_room_uuid') = 0,
+    'CREATE INDEX idx_time_block_modified_at_room_uuid ON time_block (modified_at, room_uuid)', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- 로그인(회원) 가입 추이: users.created_at 범위 스캔 (deleted_at IS NULL 은 잔여 필터)
+SET @ddl := IF(
+    (SELECT COUNT(*) FROM information_schema.statistics
+     WHERE table_schema = DATABASE() AND table_name = 'users' AND index_name = 'idx_users_created_at') = 0,
+    'CREATE INDEX idx_users_created_at ON users (created_at)', 'SELECT 1');
+PREPARE s FROM @ddl; EXECUTE s; DEALLOCATE PREPARE s;
+
+-- (선택) 게스트 추이가 무거워지면 user_id+created_at 복합으로 잔여 필터 제거:
+-- CREATE INDEX idx_participant_user_id_created_at ON participant (user_id, created_at);

--- a/db/migrations/V20260614_4_CREATE_ADMINS.sql
+++ b/db/migrations/V20260614_4_CREATE_ADMINS.sql
@@ -1,0 +1,23 @@
+# 요약: 어드민 인증(#169)용 admins 테이블 생성 — prod(ddl-auto=none)에 누락되어 있던 DDL 보강
+---
+-- Admin 엔티티(@Table(name="admins"))에 대응. local/test 는 H2 가 엔티티에서 자동 생성하므로
+-- 이 스크립트는 prod 수동 적용용이다. 어드민 계정 INSERT 는 평문 비밀번호(운영 비밀)이므로
+-- 이 파일에 포함하지 않고, 배포 시 별도 SQL 로 등록한다(비밀번호는 추후 BCrypt 전환 예정).
+
+CREATE TABLE admins (
+    id                    BIGINT       NOT NULL AUTO_INCREMENT,
+    username              VARCHAR(255) NOT NULL,
+    password              VARCHAR(255) NOT NULL,
+    refresh_token         VARCHAR(512) NULL,
+    token_expiration_time DATETIME(6)  NULL,
+    created_by            VARCHAR(50)  NULL COMMENT '생성자',
+    created_at            DATETIME(6)  NULL COMMENT '생성일시',
+    modified_by           VARCHAR(50)  NULL COMMENT '수정자',
+    modified_at           DATETIME(6)  NULL COMMENT '수정일시',
+    PRIMARY KEY (id),
+    CONSTRAINT uniqueAdminUsername UNIQUE (username)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 운영 계정 등록 예시 (배포 시 실제 비밀번호로 별도 실행):
+-- INSERT INTO admins (username, password, created_by, modified_by, created_at, modified_at)
+-- VALUES ('superadmin', '<운영_비밀번호>', 'system', 'system', NOW(6), NOW(6));

--- a/src/docs/asciidoc/admin-metrics.adoc
+++ b/src/docs/asciidoc/admin-metrics.adoc
@@ -1,0 +1,38 @@
+[[Admin-Metrics]]
+=== 어드민 대시보드 요약 지표 조회
+
+* 어드민 "대시보드" 상단 StatCard 4종에 쓰이는 현재 시점 집계 스냅샷입니다. `Authorization: Bearer {accessToken}` (어드민 토큰) 이 필요합니다.
+* 7개 필드 모두 음수 아닌 정수이며, 데이터가 없으면 `0` 입니다.
+* `totalUsers == loggedInUsers + anonymousUsers` 불변식을 보장합니다. (`activeRooms` 는 최근 7일 내 참여 활동 기준, `anonymousUsers` 는 게스트 참여 건수)
+
+[discrete]
+==== 요청
+
+include::{snippets}/admin-get-metrics/curl-request.adoc[]
+include::{snippets}/admin-get-metrics/http-request.adoc[]
+include::{snippets}/admin-get-metrics/request-headers.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/admin-get-metrics/http-response.adoc[]
+include::{snippets}/admin-get-metrics/response-fields.adoc[]
+
+=== 어드민 대시보드 추이 조회
+
+* 추이 그래프 3종(방 생성 / 사용자 가입 / 참여자)에 쓰입니다. `daily` 는 정확히 30개(최근 30일), `monthly` 는 정확히 12개(최근 12개월)입니다.
+* 배열 순서는 오래된 구간 → 최신 구간이며, 데이터가 없는 구간도 값 `0` 으로 채웁니다(구간 누락 없음).
+* 라벨은 KST 기준으로 daily 는 `"M/D"`, monthly 는 `"M월"` 형식입니다.
+
+[discrete]
+==== 요청
+
+include::{snippets}/admin-get-metrics-trends/curl-request.adoc[]
+include::{snippets}/admin-get-metrics-trends/http-request.adoc[]
+include::{snippets}/admin-get-metrics-trends/request-headers.adoc[]
+
+[discrete]
+==== 응답
+
+include::{snippets}/admin-get-metrics-trends/http-response.adoc[]
+include::{snippets}/admin-get-metrics-trends/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -46,6 +46,7 @@ include::auth-oauth2.adoc[]
 
 include::admin-auth.adoc[]
 include::admin-feedback.adoc[]
+include::admin-metrics.adoc[]
 
 // 코드
 include::timeblock.adoc[]

--- a/src/main/java/com/dnd/modutime/core/admin/metrics/application/AdminMetricsService.java
+++ b/src/main/java/com/dnd/modutime/core/admin/metrics/application/AdminMetricsService.java
@@ -1,0 +1,157 @@
+package com.dnd.modutime.core.admin.metrics.application;
+
+import com.dnd.modutime.core.admin.metrics.application.response.ServiceMetrics;
+import com.dnd.modutime.core.admin.metrics.application.response.ServiceTrends;
+import com.dnd.modutime.core.admin.metrics.application.response.TrendPoint;
+import com.dnd.modutime.core.participant.domain.ParticipantQueryRepository;
+import com.dnd.modutime.core.room.repository.RoomRepository;
+import com.dnd.modutime.core.timeblock.repository.TimeBlockRepository;
+import com.dnd.modutime.core.user.UserRepository;
+import com.dnd.modutime.util.TimeProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 어드민 대시보드 메트릭(요약 지표 + 추이) 유스케이스.
+ *
+ * <p>집계는 기존 도메인 레포지토리를 재사용해 읽기 전용으로 수행한다. 추이는 DB 방언에 의존하지 않도록
+ * createdAt 원본을 조회한 뒤 {@link TimeProvider} 기준 KST 로 일별/월별 버킷에 직접 분배한다.</p>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminMetricsService {
+
+    private static final int ACTIVE_WINDOW_DAYS = 7;
+    private static final int DAILY_POINTS = 30;
+    private static final int MONTHLY_POINTS = 12;
+
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+    private final TimeBlockRepository timeBlockRepository;
+    private final ParticipantQueryRepository participantQueryRepository;
+    private final TimeProvider timeProvider;
+
+    /**
+     * 현재 시점 요약 지표. totalUsers 는 loggedIn + anonymous 합으로 산출해 불변식을 보장한다.
+     */
+    public ServiceMetrics getMetrics() {
+        var now = timeProvider.getCurrentLocalDateTime();
+        var sevenDaysAgo = now.minusDays(ACTIVE_WINDOW_DAYS);
+
+        long loggedInUsers = userRepository.count();
+        long anonymousUsers = participantQueryRepository.countByUserIdIsNull();
+        long totalRooms = roomRepository.count();
+        long activeRooms = timeBlockRepository.countActiveRoomsSince(sevenDaysAgo);
+        long totalParticipants = participantQueryRepository.countAll();
+        long newRoomsLast7d = roomRepository.countByCreatedAtAfter(sevenDaysAgo);
+
+        return ServiceMetrics.of(
+                loggedInUsers, anonymousUsers, totalRooms, activeRooms, totalParticipants, newRoomsLast7d);
+    }
+
+    /**
+     * 일별(최근 30일) · 월별(최근 12개월) 추이. 각 소스의 createdAt 을 KST 날짜/월 버킷에 분배한다.
+     */
+    public ServiceTrends getTrends() {
+        var today = timeProvider.getCurrentLocalDateTime().toLocalDate();
+        var currentMonth = YearMonth.from(today);
+
+        // 12개월 전 1일 0시 — daily(30일)·monthly(12개월) 양쪽을 모두 덮는 가장 이른 기준 시각.
+        var from = currentMonth.minusMonths(MONTHLY_POINTS - 1L).atDay(1).atStartOfDay();
+
+        var roomCreatedAts = roomRepository.findCreatedAtsAfter(from);
+        var userCreatedAts = userRepository.findCreatedAtsAfter(from);
+        var guestCreatedAts = participantQueryRepository.findGuestCreatedAtsAfter(from);
+        var participantCreatedAts = participantQueryRepository.findCreatedAtsAfter(from);
+
+        var daily = buildDaily(today, roomCreatedAts, userCreatedAts, guestCreatedAts, participantCreatedAts);
+        var monthly = buildMonthly(currentMonth, roomCreatedAts, userCreatedAts, guestCreatedAts, participantCreatedAts);
+        return new ServiceTrends(daily, monthly);
+    }
+
+    private List<TrendPoint> buildDaily(LocalDate today,
+                                        List<LocalDateTime> rooms,
+                                        List<LocalDateTime> users,
+                                        List<LocalDateTime> guests,
+                                        List<LocalDateTime> participants) {
+        var dates = new ArrayList<LocalDate>(DAILY_POINTS);
+        for (int i = DAILY_POINTS - 1; i >= 0; i--) {
+            dates.add(today.minusDays(i));
+        }
+        var roomCounts = countByDate(rooms);
+        var userCounts = countByDate(users);
+        var guestCounts = countByDate(guests);
+        var participantCounts = countByDate(participants);
+
+        var points = new ArrayList<TrendPoint>(DAILY_POINTS);
+        for (var date : dates) {
+            points.add(new TrendPoint(
+                    date.getMonthValue() + "/" + date.getDayOfMonth(),
+                    roomCounts.getOrDefault(date, 0L),
+                    userCounts.getOrDefault(date, 0L),
+                    guestCounts.getOrDefault(date, 0L),
+                    participantCounts.getOrDefault(date, 0L)
+            ));
+        }
+        return points;
+    }
+
+    private List<TrendPoint> buildMonthly(YearMonth currentMonth,
+                                          List<LocalDateTime> rooms,
+                                          List<LocalDateTime> users,
+                                          List<LocalDateTime> guests,
+                                          List<LocalDateTime> participants) {
+        var months = new ArrayList<YearMonth>(MONTHLY_POINTS);
+        for (int i = MONTHLY_POINTS - 1; i >= 0; i--) {
+            months.add(currentMonth.minusMonths(i));
+        }
+        var roomCounts = countByMonth(rooms);
+        var userCounts = countByMonth(users);
+        var guestCounts = countByMonth(guests);
+        var participantCounts = countByMonth(participants);
+
+        var points = new ArrayList<TrendPoint>(MONTHLY_POINTS);
+        for (var month : months) {
+            points.add(new TrendPoint(
+                    month.getMonthValue() + "월",
+                    roomCounts.getOrDefault(month, 0L),
+                    userCounts.getOrDefault(month, 0L),
+                    guestCounts.getOrDefault(month, 0L),
+                    participantCounts.getOrDefault(month, 0L)
+            ));
+        }
+        return points;
+    }
+
+    private Map<LocalDate, Long> countByDate(List<LocalDateTime> createdAts) {
+        var counts = new LinkedHashMap<LocalDate, Long>();
+        for (var createdAt : createdAts) {
+            if (createdAt == null) {
+                continue;
+            }
+            counts.merge(createdAt.toLocalDate(), 1L, Long::sum);
+        }
+        return counts;
+    }
+
+    private Map<YearMonth, Long> countByMonth(List<LocalDateTime> createdAts) {
+        var counts = new LinkedHashMap<YearMonth, Long>();
+        for (var createdAt : createdAts) {
+            if (createdAt == null) {
+                continue;
+            }
+            counts.merge(YearMonth.from(createdAt), 1L, Long::sum);
+        }
+        return counts;
+    }
+}

--- a/src/main/java/com/dnd/modutime/core/admin/metrics/application/response/ServiceMetrics.java
+++ b/src/main/java/com/dnd/modutime/core/admin/metrics/application/response/ServiceMetrics.java
@@ -1,0 +1,36 @@
+package com.dnd.modutime.core.admin.metrics.application.response;
+
+/**
+ * 어드민 대시보드 상단 StatCard 4종에 쓰이는 현재 시점 요약 지표.
+ *
+ * <p>모든 값은 음수가 아닌 정수이며, 데이터가 없으면 {@code 0} 이다(null 금지).
+ * 프론트가 로그인/비로그인 비율을 계산하므로 {@code totalUsers == loggedInUsers + anonymousUsers} 불변식을 보장한다.
+ * 응답 키는 단일 단어 camelCase 로 그대로 직렬화된다.</p>
+ */
+public record ServiceMetrics(
+        long totalUsers,
+        long loggedInUsers,
+        long anonymousUsers,
+        long totalRooms,
+        long activeRooms,
+        long totalParticipants,
+        long newRoomsLast7d
+) {
+
+    public static ServiceMetrics of(long loggedInUsers,
+                                    long anonymousUsers,
+                                    long totalRooms,
+                                    long activeRooms,
+                                    long totalParticipants,
+                                    long newRoomsLast7d) {
+        return new ServiceMetrics(
+                loggedInUsers + anonymousUsers,
+                loggedInUsers,
+                anonymousUsers,
+                totalRooms,
+                activeRooms,
+                totalParticipants,
+                newRoomsLast7d
+        );
+    }
+}

--- a/src/main/java/com/dnd/modutime/core/admin/metrics/application/response/ServiceTrends.java
+++ b/src/main/java/com/dnd/modutime/core/admin/metrics/application/response/ServiceTrends.java
@@ -1,0 +1,15 @@
+package com.dnd.modutime.core.admin.metrics.application.response;
+
+import java.util.List;
+
+/**
+ * 어드민 대시보드 하단 추이 그래프 3종(방 생성/사용자 가입/참여자)에 쓰이는 일별·월별 추이.
+ *
+ * <p>{@code daily} 는 정확히 30개(최근 30일), {@code monthly} 는 정확히 12개(최근 12개월)이며,
+ * 배열 순서는 오래된 구간 → 최신 구간이다.</p>
+ */
+public record ServiceTrends(
+        List<TrendPoint> daily,
+        List<TrendPoint> monthly
+) {
+}

--- a/src/main/java/com/dnd/modutime/core/admin/metrics/application/response/TrendPoint.java
+++ b/src/main/java/com/dnd/modutime/core/admin/metrics/application/response/TrendPoint.java
@@ -1,0 +1,16 @@
+package com.dnd.modutime.core.admin.metrics.application.response;
+
+/**
+ * 추이 그래프의 한 구간(일별 또는 월별) 데이터 포인트.
+ *
+ * <p>{@code label} 은 x축 라벨로, daily 는 {@code "M/D"}, monthly 는 {@code "M월"} 형식이다(KST 기준).
+ * 나머지 값은 해당 구간의 신규 발생 수이며, 빈 구간도 {@code 0} 으로 채운다.</p>
+ */
+public record TrendPoint(
+        String label,
+        long rooms,
+        long loggedIn,
+        long anonymous,
+        long participants
+) {
+}

--- a/src/main/java/com/dnd/modutime/core/admin/metrics/controller/AdminMetricsController.java
+++ b/src/main/java/com/dnd/modutime/core/admin/metrics/controller/AdminMetricsController.java
@@ -1,0 +1,31 @@
+package com.dnd.modutime.core.admin.metrics.controller;
+
+import com.dnd.modutime.core.admin.metrics.application.AdminMetricsService;
+import com.dnd.modutime.core.admin.metrics.application.response.ServiceMetrics;
+import com.dnd.modutime.core.admin.metrics.application.response.ServiceTrends;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 어드민 "대시보드" 메뉴용 메트릭 API.
+ *
+ * <p>{@code /admin/**} 경로는 {@code AdminSecurityConfig} 체인이 어드민 access token 인증을 강제하므로
+ * 별도 인증 애너테이션은 필요 없다.</p>
+ */
+@RestController
+@RequiredArgsConstructor
+public class AdminMetricsController {
+
+    private final AdminMetricsService adminMetricsService;
+
+    @GetMapping("/admin/api/v1/metrics")
+    public ServiceMetrics getMetrics() {
+        return adminMetricsService.getMetrics();
+    }
+
+    @GetMapping("/admin/api/v1/metrics/trends")
+    public ServiceTrends getTrends() {
+        return adminMetricsService.getTrends();
+    }
+}

--- a/src/main/java/com/dnd/modutime/core/participant/domain/ParticipantQueryRepository.java
+++ b/src/main/java/com/dnd/modutime/core/participant/domain/ParticipantQueryRepository.java
@@ -1,9 +1,24 @@
 package com.dnd.modutime.core.participant.domain;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ParticipantQueryRepository {
+
+    @Query("select count(p) from Participant p")
+    long countAll();
+
+    long countByUserIdIsNull();
+
+    @Query("select p.createdAt from Participant p where p.createdAt >= :from")
+    List<LocalDateTime> findCreatedAtsAfter(@Param("from") LocalDateTime from);
+
+    @Query("select p.createdAt from Participant p where p.userId is null and p.createdAt >= :from")
+    List<LocalDateTime> findGuestCreatedAtsAfter(@Param("from") LocalDateTime from);
+
     Optional<Participant> findByRoomUuidAndName(String roomUuid, String name);
 
     boolean existsByRoomUuidAndName(String roomUuid, String name);

--- a/src/main/java/com/dnd/modutime/core/room/repository/RoomRepository.java
+++ b/src/main/java/com/dnd/modutime/core/room/repository/RoomRepository.java
@@ -1,10 +1,19 @@
 package com.dnd.modutime.core.room.repository;
 
 import com.dnd.modutime.core.room.domain.Room;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
     Optional<Room> findByUuid(String uuid);
+
+    long countByCreatedAtAfter(LocalDateTime from);
+
+    @Query("select r.createdAt from Room r where r.createdAt >= :from")
+    List<LocalDateTime> findCreatedAtsAfter(@Param("from") LocalDateTime from);
 }

--- a/src/main/java/com/dnd/modutime/core/timeblock/repository/TimeBlockRepository.java
+++ b/src/main/java/com/dnd/modutime/core/timeblock/repository/TimeBlockRepository.java
@@ -1,9 +1,12 @@
 package com.dnd.modutime.core.timeblock.repository;
 
 import com.dnd.modutime.core.timeblock.domain.TimeBlock;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TimeBlockRepository extends JpaRepository<TimeBlock, Long> {
 
@@ -12,4 +15,10 @@ public interface TimeBlockRepository extends JpaRepository<TimeBlock, Long> {
     List<TimeBlock> findByRoomUuid(String roomUuid);
 
     boolean existsByRoomUuid(String roomUuid);
+
+    /**
+     * 최근 활성 방 수 — modifiedAt(참여자 시간 블록의 최종 수정 시각)이 기준 시각 이후인 방의 distinct 개수.
+     */
+    @Query("select count(distinct t.roomUuid) from TimeBlock t where t.modifiedAt >= :from")
+    long countActiveRoomsSince(@Param("from") LocalDateTime from);
 }

--- a/src/main/java/com/dnd/modutime/core/user/UserRepository.java
+++ b/src/main/java/com/dnd/modutime/core/user/UserRepository.java
@@ -1,11 +1,18 @@
 package com.dnd.modutime.core.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByRefreshToken(String refreshToken);
     Optional<User> findByEmailAndProvider(String email, OAuth2Provider provider);
+
+    @Query("select u.createdAt from User u where u.createdAt >= :from")
+    List<LocalDateTime> findCreatedAtsAfter(@Param("from") LocalDateTime from);
 }

--- a/src/test/java/com/dnd/modutime/controller/admin/AdminMetricsControllerDocsTest.java
+++ b/src/test/java/com/dnd/modutime/controller/admin/AdminMetricsControllerDocsTest.java
@@ -1,0 +1,159 @@
+package com.dnd.modutime.controller.admin;
+
+import com.dnd.modutime.annotation.ApiDocsTest;
+import com.dnd.modutime.core.admin.metrics.application.AdminMetricsService;
+import com.dnd.modutime.core.admin.metrics.application.response.ServiceMetrics;
+import com.dnd.modutime.core.admin.metrics.application.response.ServiceTrends;
+import com.dnd.modutime.core.admin.metrics.application.response.TrendPoint;
+import com.dnd.modutime.core.admin.metrics.controller.AdminMetricsController;
+import com.dnd.modutime.documentation.DocumentUtils;
+import com.dnd.modutime.documentation.MockMvcFactory;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceDocumentation;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.headers.HeaderDocumentation;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+
+import java.util.List;
+
+import static com.dnd.modutime.TestConstant.LOCALHOST;
+import static com.dnd.modutime.documentation.MockMvcFactory.HEADER_AUTHORIZATION;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ApiDocsTest
+public class AdminMetricsControllerDocsTest {
+
+    @Mock
+    private AdminMetricsService adminMetricsService;
+
+    @InjectMocks
+    private AdminMetricsController controller;
+
+    private static final HeaderDescriptor[] AUTH_HEADERS = new HeaderDescriptor[]{
+            headerWithName("Authorization").description("어드민 access token (Bearer {accessToken})")
+    };
+
+    @DisplayName("어드민 대시보드 요약 지표 조회")
+    @Test
+    void 요약_지표_조회(RestDocumentationContextProvider contextProvider) throws Exception {
+        var operationIdentifier = "admin-get-metrics";
+        var responseFields = new FieldDescriptor[]{
+                fieldWithPath("totalUsers").type(NUMBER).description("전체 사용자 수 (로그인 + 비로그인)"),
+                fieldWithPath("loggedInUsers").type(NUMBER).description("로그인(회원) 사용자 수"),
+                fieldWithPath("anonymousUsers").type(NUMBER).description("비로그인(게스트) 사용자 수"),
+                fieldWithPath("totalRooms").type(NUMBER).description("누적 방 갯수"),
+                fieldWithPath("activeRooms").type(NUMBER).description("최근 7일 활성 방 갯수 (최근 7일 내 참여 활동)"),
+                fieldWithPath("totalParticipants").type(NUMBER).description("누적 참여자 수"),
+                fieldWithPath("newRoomsLast7d").type(NUMBER).description("최근 7일 신규 방 갯수")
+        };
+
+        when(adminMetricsService.getMetrics())
+                .thenReturn(new ServiceMetrics(4820, 1735, 3085, 9240, 412, 38150, 286));
+
+        MockMvcFactory.getRestDocsMockMvc(contextProvider, LOCALHOST, controller)
+                .perform(
+                        get("/admin/api/v1/metrics")
+                                .header("Authorization", HEADER_AUTHORIZATION)
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        MockMvcRestDocumentation.document(
+                                operationIdentifier,
+                                DocumentUtils.getDocumentRequest(),
+                                DocumentUtils.getDocumentResponse(),
+                                HeaderDocumentation.requestHeaders(AUTH_HEADERS),
+                                PayloadDocumentation.responseFields(responseFields)
+                        )
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document(
+                                operationIdentifier,
+                                DocumentUtils.getDocumentRequest(),
+                                DocumentUtils.getDocumentResponse(),
+                                ResourceDocumentation.resource(
+                                        ResourceSnippetParameters.builder()
+                                                .description("어드민 대시보드 요약 지표 조회 (현재 시점 스냅샷)")
+                                                .tag("Admin-Metrics")
+                                                .requestHeaders(AUTH_HEADERS)
+                                                .responseFields(responseFields)
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("어드민 대시보드 추이 조회 - 일별 30 / 월별 12")
+    @Test
+    void 추이_조회(RestDocumentationContextProvider contextProvider) throws Exception {
+        var operationIdentifier = "admin-get-metrics-trends";
+        var responseFields = new FieldDescriptor[]{
+                fieldWithPath("daily").type(ARRAY).description("최근 30일 일별 추이 (정확히 30개, 오래된→최신)"),
+                fieldWithPath("daily[].label").type(STRING).description("x축 라벨 (\"M/D\")"),
+                fieldWithPath("daily[].rooms").type(NUMBER).description("해당 일 신규 방 갯수"),
+                fieldWithPath("daily[].loggedIn").type(NUMBER).description("해당 일 신규 로그인 사용자"),
+                fieldWithPath("daily[].anonymous").type(NUMBER).description("해당 일 신규 비로그인 사용자"),
+                fieldWithPath("daily[].participants").type(NUMBER).description("해당 일 참여자 수"),
+                fieldWithPath("monthly").type(ARRAY).description("최근 12개월 월별 추이 (정확히 12개, 오래된→최신)"),
+                fieldWithPath("monthly[].label").type(STRING).description("x축 라벨 (\"M월\")"),
+                fieldWithPath("monthly[].rooms").type(NUMBER).description("해당 월 신규 방 갯수"),
+                fieldWithPath("monthly[].loggedIn").type(NUMBER).description("해당 월 신규 로그인 사용자"),
+                fieldWithPath("monthly[].anonymous").type(NUMBER).description("해당 월 신규 비로그인 사용자"),
+                fieldWithPath("monthly[].participants").type(NUMBER).description("해당 월 참여자 수")
+        };
+
+        when(adminMetricsService.getTrends())
+                .thenReturn(new ServiceTrends(
+                        List.of(new TrendPoint("6/13", 18, 6, 11, 70),
+                                new TrendPoint("6/14", 24, 8, 14, 98)),
+                        List.of(new TrendPoint("5월", 520, 180, 320, 2100),
+                                new TrendPoint("6월", 286, 96, 175, 1240))
+                ));
+
+        MockMvcFactory.getRestDocsMockMvc(contextProvider, LOCALHOST, controller)
+                .perform(
+                        get("/admin/api/v1/metrics/trends")
+                                .header("Authorization", HEADER_AUTHORIZATION)
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        MockMvcRestDocumentation.document(
+                                operationIdentifier,
+                                DocumentUtils.getDocumentRequest(),
+                                DocumentUtils.getDocumentResponse(),
+                                HeaderDocumentation.requestHeaders(AUTH_HEADERS),
+                                PayloadDocumentation.responseFields(responseFields)
+                        )
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document(
+                                operationIdentifier,
+                                DocumentUtils.getDocumentRequest(),
+                                DocumentUtils.getDocumentResponse(),
+                                ResourceDocumentation.resource(
+                                        ResourceSnippetParameters.builder()
+                                                .description("어드민 대시보드 추이 조회 (일별 30 / 월별 12)")
+                                                .tag("Admin-Metrics")
+                                                .requestHeaders(AUTH_HEADERS)
+                                                .responseFields(responseFields)
+                                                .build())
+                        )
+                );
+    }
+}


### PR DESCRIPTION
## 개요
어드민 "대시보드" 메뉴용 백엔드 메트릭 API 2종을 추가합니다. (프론트 `elastic-buffalo/docs/metrics-api.md` §1·§2 계약 준수 → `NEXT_PUBLIC_METRICS_API_READY=true`만 켜면 실연동)

| Method | Path | 용도 |
|---|---|---|
| GET | `/admin/api/v1/metrics` | 현재 시점 요약 지표(7필드) |
| GET | `/admin/api/v1/metrics/trends` | 일별 30 / 월별 12 추이 |

기존 `/admin/**` 어드민 JWT 체인(#169)으로 자동 보호되어 별도 인증 코드는 없습니다.

## 주요 결정
- **activeRooms**: 최근 7일 내 `time_block` 활동(참여) 기준 distinct room
- **anonymousUsers**: 게스트 participant(`user_id IS NULL`) 수
- **totalUsers = loggedInUsers + anonymousUsers** 합산 산출로 불변식 보장
- 추이는 DB 방언 비의존 위해 `created_at` 원본을 `TimeProvider` 기준 **KST로 Java 버킷팅** (라벨 `M/D`·`M월`, 빈 구간 0)
- 응답 키는 단일 단어 camelCase

## 변경 사항
- `core/admin/metrics/**` — 컨트롤러/서비스/응답 record 3종
- Room/User/TimeBlock/Participant 레포에 집계 쿼리 추가
- REST Docs 테스트(`AdminMetricsControllerDocsTest`) + `admin-metrics.adoc`(index include)
- `V20260614_3_CREATE_METRICS_INDEXES.sql` — 집계 성능 인덱스(멱등)
- `V20260614_4_CREATE_ADMINS.sql` — **#169에서 누락된 admins 테이블 DDL 보강** (prod `ddl-auto=none`이라 없으면 어드민 로그인 불가 → 본 기능의 전제). 별도 커밋으로 분리.

## 검증
- `./gradlew test` / `apiDocsTest asciidoctor` ✅
- 실부팅 e2e ✅ — 요약 7필드, 추이 30/12, 라벨 형식, `totalUsers==loggedIn+anonymous` 불변식, 무토큰/위조토큰 401 격리 전부 통과

## 적용 노트(운영)
prod는 `ddl-auto=none`이라 `db/migrations/V20260614_3`, `V20260614_4`를 수동 적용해야 합니다. (local/test는 H2 자동 생성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 어드민 대시보드 메트릭 조회 API 추가 (요약 지표: 사용자, 방, 참여자 수)
  * 일별/월별 추이 그래프 데이터 API 추가
  * 어드민 인증 시스템 도입

* **Documentation**
  * 어드민 메트릭 API 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->