### PR TITLE
fix(timetable): date-only 방 수정 시 참가자 시간 누락 수정 (#167 회귀)

### DIFF
--- a/src/main/java/com/dnd/modutime/core/timetable/domain/DateInfo.java
+++ b/src/main/java/com/dnd/modutime/core/timetable/domain/DateInfo.java
@@ -106,7 +106,7 @@ public class DateInfo implements Auditable {
             return;
         }
         List<AvailableTime> timesOrNull = availableDateTime.getTimesOrNull();
-        if (timesOrNull == null) {
+        if (timesOrNull == null || timesOrNull.isEmpty()) {
             validateTimeInfoIsEmpty();
             TimeInfo timeInfo = timeInfos.get(0);
             timeInfo.addParticipantName(participantName);

--- a/src/test/java/com/dnd/modutime/core/timetable/domain/DateInfoTest.java
+++ b/src/test/java/com/dnd/modutime/core/timetable/domain/DateInfoTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,9 +31,9 @@ public class DateInfoTest {
         dateInfo.removeParticipantNameIfSameDate(new AvailableDateTime(new TimeBlock(ROOM_UUID, "참여자1"), _2023_02_09,
                 List.of(new AvailableTime(_12_00))), "참여자1");
         TimeInfo timeInfo = dateInfo.getTimeInfos().get(0);
-        assertThat(timeInfo.getTimeInfoParticipantNames().stream()
-                .map(TimeInfoParticipantName::getName)
-                .collect(Collectors.toList())).contains("참여자1");
+        assertThat(timeInfo.getTimeInfoParticipantNames())
+                .extracting(TimeInfoParticipantName::getName)
+                .contains("참여자1");
     }
 
     @Test
@@ -46,9 +45,9 @@ public class DateInfoTest {
         dateInfo.removeParticipantNameIfSameDate(new AvailableDateTime(new TimeBlock(ROOM_UUID, "참여자1"), _2023_02_10,
                 null), "참여자1");
         TimeInfo timeInfo = dateInfo.getTimeInfos().get(0);
-        assertThat(timeInfo.getTimeInfoParticipantNames().stream()
-                .map(TimeInfoParticipantName::getName)
-                .collect(Collectors.toList())).doesNotContain("참여자1");
+        assertThat(timeInfo.getTimeInfoParticipantNames())
+                .extracting(TimeInfoParticipantName::getName)
+                .doesNotContain("참여자1");
     }
 
     @Test
@@ -114,9 +113,9 @@ public class DateInfoTest {
                 null), "참여자1");
 
         TimeInfo timeInfo = dateInfo.getTimeInfos().get(0);
-        assertThat(timeInfo.getTimeInfoParticipantNames().stream()
-                .map(TimeInfoParticipantName::getName)
-                .collect(Collectors.toList())).contains("참여자1");
+        assertThat(timeInfo.getTimeInfoParticipantNames())
+                .extracting(TimeInfoParticipantName::getName)
+                .contains("참여자1");
     }
 
     @Test
@@ -127,9 +126,9 @@ public class DateInfoTest {
                 List.of()), "참여자1");
 
         TimeInfo timeInfo = dateInfo.getTimeInfos().get(0);
-        assertThat(timeInfo.getTimeInfoParticipantNames().stream()
-                .map(TimeInfoParticipantName::getName)
-                .collect(Collectors.toList())).contains("참여자1");
+        assertThat(timeInfo.getTimeInfoParticipantNames())
+                .extracting(TimeInfoParticipantName::getName)
+                .contains("참여자1");
     }
 
 //    private DateInfo getDateInfo(List<TimeInfo> timeInfos) {

--- a/src/test/java/com/dnd/modutime/core/timetable/domain/DateInfoTest.java
+++ b/src/test/java/com/dnd/modutime/core/timetable/domain/DateInfoTest.java
@@ -119,6 +119,19 @@ public class DateInfoTest {
                 .collect(Collectors.toList())).contains("참여자1");
     }
 
+    @Test
+    void date가_같고_시간이_빈리스트여도_참여자를_추가한다() {
+        // DB에서 로드된 date-only AvailableDateTime의 times는 null이 아니라 빈 리스트([])다.
+        DateInfo dateInfo = getDateInfo(List.of(getTimeInfo(null)));
+        dateInfo.addParticipantNameIfSameDate(new AvailableDateTime(new TimeBlock(ROOM_UUID, "참여자1"), _2023_02_10,
+                List.of()), "참여자1");
+
+        TimeInfo timeInfo = dateInfo.getTimeInfos().get(0);
+        assertThat(timeInfo.getTimeInfoParticipantNames().stream()
+                .map(TimeInfoParticipantName::getName)
+                .collect(Collectors.toList())).contains("참여자1");
+    }
+
 //    private DateInfo getDateInfo(List<TimeInfo> timeInfos) {
 //        return new DateInfo(getTimeTable(), _2023_02_10, timeInfos);
 //    }


### PR DESCRIPTION
## 문제

date-only(날짜만) 방에서 참가자가 **이미 등록한 일정을 수정**하면, 유지된(carry-over) 날짜가 TimeBlock에는 남지만 **TimeTable/AdjustmentResult에서는 사라져** `available-time`은 정상인데 `overview`/`adjustment-result`가 `count=0`으로 비어 나오는 현상.

- `GET /api/v1/rooms/{uuid}/available-time` → 등록한 날짜 정상 (TimeBlock 직접 조회)
- `GET /guest/api/room/{uuid}/available-time/overview` → 해당 날짜 `count=0` (TimeTable 조회)

## 원인 (회귀 #167)

`DateInfo`의 date-only 판정 조건이 메서드마다 불일치했다.

| 메서드 | 판정 | 상태 |
|---|---|---|
| `getTimeInfoIdsByAvailableDateTime` | `times == null \|\| isEmpty()` | ✅ |
| `removeParticipantNameIfSameDate` | `times == null \|\| isEmpty()` | ✅ |
| **`addParticipantNameIfSameDate`** | **`times == null` 만** | ❌ |

`#167`(available-time diff 갱신)부터 `TimeBlockReplaceEvent` payload가 **DB에서 로드된 '유지분(kept)' `AvailableDateTime`** 을 포함하게 됐는데, date-only 엔티티의 `@OneToMany times`는 `null`이 아니라 **빈 PersistentBag(`[]`)** 으로 로드된다. 이 경우 `add`만 null 분기를 타지 못하고 빈 시간슬롯 매칭(`forEach` over 빈 리스트)으로 빠져 **참가자를 조용히 추가하지 않는다.** `remove`는 정상 동작하므로, 수정 시 유지된 날짜가 TimeTable에서 제거된 뒤 재추가되지 않아 `count=0`이 된다.

## 영향 범위 (실측 검증)

H2 통합 검증 결과, payload의 `times`가 `null`이면 정상이고 `[]`이면 누락:

- **최초 제출**: 전부 `toAdd`(times=null) → 정상 반영. **안 깨짐.**
- **수정/재제출**: 유지된 날짜는 DB 재로드(times=`[]`) → 누락. **깨짐.** (새로 추가한 날짜는 정상)
- 한 번 깨지면 동일 재제출은 no-op early-return(#167)이라 자가복구 안 됨.
- **date+time 방은 영향 없음** (times가 항상 특정시간 리스트라 해당 경로는 정상).
- 영향 시작: #167 배포(2026-05-31) 이후 수정이 발생한 date-only 방.

## 수정

`addParticipantNameIfSameDate`의 판정을 형제 메서드와 동일하게 `times == null || isEmpty()`로 일원화 (1줄). 빈 리스트 케이스 회귀 테스트 추가.

## 검증

- 회귀 테스트 `date가_같고_시간이_빈리스트여도_참여자를_추가한다()`: 수정 전 FAIL → 수정 후 PASS
- 전체 테스트 스위트 통과 (`./gradlew test` BUILD SUCCESSFUL)

## 운영 데이터 복구 (배포 후 별도 필요)

기존에 깨진 방은 코드 배포만으로 자동 복구되지 않는다. 영향 (방·참가자·날짜)는 진단 쿼리로 추출 후, ① 영향 참가자 일정 재트리거(값 변경 PUT, TimeTable+AdjustmentResult 모두 정합) 또는 ② `time_info_participant_name` SQL 백필(overview만 복구, AdjustmentResult 재계산 별도)로 복구. 상세 쿼리/절차는 후속 코멘트 참고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)